### PR TITLE
Add -r to output raw string

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,6 +33,8 @@ type cli struct {
 	inStream  io.Reader
 	outStream io.Writer
 	errStream io.Writer
+
+	outputRaw bool
 }
 
 func (cli *cli) run(args []string) int {
@@ -52,6 +54,7 @@ Options:
 		fs.PrintDefaults()
 	}
 	var showVersion bool
+	fs.BoolVar(&cli.outputRaw, "r", false, "output raw string")
 	fs.BoolVar(&showVersion, "v", false, "print version")
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
@@ -165,6 +168,10 @@ func (cli *cli) printValue(v <-chan interface{}) error {
 	for x := range v {
 		if err, ok := x.(error); ok {
 			return err
+		}
+		if cli.outputRaw {
+			fmt.Fprint(cli.outStream, x)
+			continue
 		}
 		xs, err := jsonFormatter().Marshal(x)
 		if err != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,15 +18,19 @@ func TestCliRun(t *testing.T) {
 	defer f.Close()
 
 	var testCases []struct {
-		Name     string
-		Args     []string
-		Input    string
-		Expected string
-		Error    string
+		Name          string
+		Args          []string
+		Input         string
+		Expected      string
+		Error         string
+		SkipOnWindows bool `yaml:"skip-on-windows"`
 	}
 	require.NoError(t, yaml.NewDecoder(f).Decode(&testCases))
 
 	for _, tc := range testCases {
+		if runtime.GOOS == "windows" && tc.SkipOnWindows {
+			continue
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			outStream := new(bytes.Buffer)
 			errStream := new(bytes.Buffer)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -47,3 +47,20 @@ func TestCliRun(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputRaw(t *testing.T) {
+	input := `{"foo": [1, null], "baz": {"foo": [true, "bar"], "baz": "multiple\nline"}}`
+	query := `.baz.baz`
+
+	outStream := new(bytes.Buffer)
+	errStream := new(bytes.Buffer)
+	cli := cli{
+		inStream:  strings.NewReader(input),
+		outStream: outStream,
+		errStream: errStream,
+	}
+	code := cli.run([]string{"-r", query})
+	assert.Equal(t, exitCodeOK, code)
+	assert.Equal(t, "multiple\nline", outStream.String())
+	assert.Equal(t, "", errStream.String())
+}

--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -1982,3 +1982,4 @@
     }
   error: |
     open testdata/4.json: no such file or directory
+  skip-on-windows: true


### PR DESCRIPTION
Also ignore test for file not found.

Note: still some tests are failing on Windows since colors are enabled even testinng on Windows.