### PR TITLE
Add support for compile-time variable allocation

### DIFF
--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -3759,3 +3759,27 @@
       "foo": 10
     }
   error: 'open testdata/6.json:'
+
+- name: 'single variable'
+  args:
+    - '--arg'
+    - 'mul=10'
+    - '. * $mul'
+  input: '123'
+  expected: |
+    1230
+
+- name: 'multiple variables'
+  args:
+    - '--arg=x=2'
+    - '--arg=y=3'
+    - '--arg=z=4'
+    - -n
+    - '{ x: $x, y: $y, z: $z }'
+  input: '123'
+  expected: |
+    {
+      "x": 2,
+      "y": 3,
+      "z": 4
+    }

--- a/cli/variable.go
+++ b/cli/variable.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type variable struct {
+	name string
+	raw  string // Parsed as JSON when possible, otherwise used as a raw string.
+}
+
+func variableValues(vars []*variable) (vals []interface{}) {
+	vals = make([]interface{}, len(vars))
+	for i, v := range vars {
+		vals[i] = v.Value()
+	}
+	return vals
+}
+
+func variableNames(vars []*variable) (names []string) {
+	names = make([]string, len(vars))
+	for i, v := range vars {
+		names[i] = v.name
+	}
+	return names
+}
+
+func (v *variable) Value() interface{} {
+	var val interface{}
+	if err := json.Unmarshal([]byte(v.raw), &val); err != nil {
+		return v.raw
+	}
+	return val
+}
+
+func (v *variable) UnmarshalFlag(value string) error {
+	sep := strings.IndexByte(value, '=')
+	if sep == -1 {
+		return fmt.Errorf("variable must be of the form name=value")
+	}
+	*v = variable{
+		name: "$" + value[:sep],
+		raw:  value[sep+1:],
+	}
+	return nil
+}

--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package gojq
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -112,6 +113,16 @@ type zeroModuloError struct {
 
 func (err *zeroModuloError) Error() string {
 	return fmt.Sprintf("cannot modulo %s by: %s", typeErrorPreview(err.l), typeErrorPreview(err.r))
+}
+
+var errTooManyVariables = errors.New("too many variables provided")
+
+type expectedVariableError struct {
+	n string
+}
+
+func (err *expectedVariableError) Error() string {
+	return fmt.Sprintf("variable defined but not bound: %s", err.n)
 }
 
 type variableNotFoundError struct {

--- a/execute.go
+++ b/execute.go
@@ -6,10 +6,13 @@ import (
 	"sort"
 )
 
-func (env *env) execute(bc *bytecode, v interface{}) Iter {
+func (env *env) execute(bc *Code, v interface{}, vars ...interface{}) Iter {
 	env.codes = bc.codes
 	env.codeinfos = bc.codeinfos
 	env.push(v)
+	for i := len(vars) - 1; i >= 0; i-- {
+		env.push(vars[i])
+	}
 	env.debugCodes()
 	return env
 }

--- a/query.go
+++ b/query.go
@@ -60,11 +60,11 @@ func (e *Query) toIndices() []interface{} {
 
 // Run query.
 func (e *Query) Run(v interface{}) Iter {
-	code, err := compile(e)
+	code, err := Compile(e)
 	if err != nil {
 		return unitIterator(err)
 	}
-	return newEnv().execute(code, normalizeNumbers(v))
+	return code.Run(v)
 }
 
 // Comma ...


### PR DESCRIPTION
Add support for allocating variables at compile-time and binding them
at runtime.

This renames bytecode to Code and the compile function to Compile so
that both can be exported. In turn, an additional varidiac argument has
been added to Compile to pass in the names of variables to be bound at
runtime. This requires adding the same variadic argument to (*Code).Run
to accept the variables' values.

Variable binding is mostly hacked in by inserting a number of store
opcodes at the beginning of the bytecode and ensuring that the values
provided at runtime are pushed after the main value. As such, Code now
has a vars field to identify every variable it requires to run.

Rudimentary support for this has been added to the cli package.