### PR TITLE
Add TTY detection as the default for color output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lestrrat-go/strftime v1.0.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
-	github.com/mattn/go-isatty v0.0.11 // indirect
+	github.com/mattn/go-isatty v0.0.11
 	github.com/mattn/go-runewidth v0.0.7
 	github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
Add TTY detection for the cli's output stream, since it's not always
standard output.

This is to fix test cases when run using `go test` (for some reason,
`go test ./cli` and `go test .` work, but `go test` does not), as gojq
by default produces colored output for TTYs if standard output is
a TTY. This is a problem in tests because gojq doesn't check if its
given output stream is a TTY -- only standard output. So, because the
output is colored in the `go test` case, none of the test cases pass
except for those looking for colored output.

To mitigate this, if neither monochrome or color output flags are true
(can't combine these into a single toggle due to the flags package in
use, so it's quirky right now), determine if output should be colored
by whether the output stream is a TTY using the same logic that the
color pacakge uses for standard output. For tests (now), piping into
other gojq instances, and so on, this is false. For output to
a terminal, it's usually true.
