### PR TITLE
Remove side-effects from array addition

### DIFF
--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -1713,6 +1713,24 @@
     [1,2]
     []
 
+- name: ensure arrays are immutable during addition
+  args:
+    - '. as $first | .[:0] + [6, 7, 8] | ., $first'
+  input: '[1, 2, 3, 4, 5]'
+  expected: |
+    [
+      6,
+      7,
+      8
+    ]
+    [
+      1,
+      2,
+      3,
+      4,
+      5
+    ]
+
 - name: subtract arrays
   args:
     - -c

--- a/operator.go
+++ b/operator.go
@@ -335,7 +335,15 @@ func funcOpAdd(_, l, r interface{}) interface{} {
 		func(l, r float64) interface{} { return l + r },
 		func(l, r *big.Int) interface{} { return new(big.Int).Add(l, r) },
 		func(l, r string) interface{} { return l + r },
-		func(l, r []interface{}) interface{} { return append(l, r...) },
+		func(l, r []interface{}) interface{} {
+			if len(r) == 0 {
+				return l
+			} else if len(r) == 0 {
+				return l
+			}
+			v := make([]interface{}, 0, len(l)+len(r))
+			return append(append(v, l...), r...)
+		},
 		func(l, r map[string]interface{}) interface{} {
 			m := make(map[string]interface{})
 			for k, v := range l {


### PR DESCRIPTION
When two arrays are added, gojq modifies the left-hand array, resulting
in any prior capture of the array to be modified as well if it happens
inside the capacity of the array (seen by taking the input array,
slicing it, and appending to it). Fix this copying the left-hand array
and appending to the copy. To avoid a copy when one doesn't need to
happen, only concatenate arrays when they both have non-zero length.

Includes a test case under cli that catches the previous behavior.