### PR TITLE
Fix array addition conditional

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -338,8 +338,8 @@ func funcOpAdd(_, l, r interface{}) interface{} {
 		func(l, r []interface{}) interface{} {
 			if len(r) == 0 {
 				return l
-			} else if len(r) == 0 {
-				return l
+			} else if len(l) == 0 {
+				return r
 			}
 			v := make([]interface{}, 0, len(l)+len(r))
 			return append(append(v, l...), r...)


### PR DESCRIPTION
Fixes a shortcut in array addition to avoid copying where both sides of
the conditional are the same. There are no adverse effects from the
else-if clause since the two cases are identical, but it does mean that
addition like `[] + [1]` will always result in a copy.

I should've caught this when I submitted the previous PR, but my head
decided there was definitely nothing weird going on.