### PR TITLE
Add int64 type for data unmarshaled with `UseNumber()`

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -14,6 +14,16 @@ func compare(l, r interface{}) int {
 				return 1
 			}
 		},
+		func(l int64, r int64) interface{} {
+			switch {
+			case l < r:
+				return -1
+			case l == r:
+				return 0
+			default:
+				return 1
+			}
+		},
 		func(l, r float64) interface{} {
 			switch {
 			case l < r:
@@ -88,7 +98,7 @@ func getTypeOrdNum(v interface{}) int {
 			return 2
 		}
 		return 1
-	case int, float64, *big.Int:
+	case int, int64, float64, *big.Int:
 		return 3
 	case string:
 		return 4

--- a/func.go
+++ b/func.go
@@ -440,6 +440,7 @@ func funcContains(v, x interface{}) interface{} {
 	}
 	return binopTypeSwitch(v, x,
 		func(l, r int) interface{} { return l == r },
+		func(l, r int64) interface{} { return l == r },
 		func(l, r float64) interface{} { return l == r },
 		func(l, r *big.Int) interface{} { return l.Cmp(r) == 0 },
 		func(l, r string) interface{} { return strings.Contains(l, r) },


### PR DESCRIPTION
Hi, thank you for such great project, I really like it!

Just found a minor type issue when I was using this project along with json decoder which enabled [UseNumber](https://pkg.go.dev/encoding/json?tab=doc#Decoder.UseNumber) option, and the query results for operators `>,<,>=,<=` was not correct, this mr is an attempt to fix this, and it currently works in my use case.

Thank you for your great work!
