### PR TITLE
implement eval function

### DIFF
--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -5428,6 +5428,51 @@
   error: |
     module not found: "3"
 
+- name: eval function
+  args:
+    - -c
+    - 'eval(".x[]")'
+  input: '{"x": [1,2,3]}'
+  expected: |
+    1
+    2
+    3
+
+- name: eval function
+  args:
+    - -c
+    - 'eval([".", "..", ".x", ".x[]"][] | [tojson, .][])'
+  input: '{"x": [1,2,3]}'
+  expected: |
+    "."
+    {"x":[1,2,3]}
+    ".."
+    {"x":[1,2,3]}
+    [1,2,3]
+    1
+    2
+    3
+    ".x"
+    [1,2,3]
+    ".x[]"
+    1
+    2
+    3
+
+- name: eval function error
+  args:
+    - 'eval(.x)'
+  input: '{"x": 1}'
+  error: |
+    eval cannot be applied to: number (1)
+
+- name: eval function error
+  args:
+    - 'eval(".x | error")'
+  input: '{"x": 1}'
+  error: |
+    error: 1
+
 - name: arg option
   args:
     - --arg

--- a/code.go
+++ b/code.go
@@ -31,6 +31,7 @@ const (
 	opscope
 	opret
 	opeach
+	opeval
 	opexpbegin
 	opexpend
 	oppathbegin
@@ -86,6 +87,8 @@ func (op opcode) String() string {
 		return "ret"
 	case opeach:
 		return "each"
+	case opeval:
+		return "eval"
 	case opexpbegin:
 		return "expbegin"
 	case opexpend:

--- a/compiler.go
+++ b/compiler.go
@@ -920,6 +920,12 @@ func (c *compiler) compileFunc(e *Func) error {
 				nil,
 				false,
 			)
+		case "eval":
+			if err := c.compileCallInternal(nil, e.Args, nil, false); err != nil {
+				return err
+			}
+			c.codes[len(c.codes)-1] = &code{op: opeval}
+			return nil
 		default:
 			return c.compileCall(e.Name, e.Args)
 		}

--- a/func.go
+++ b/func.go
@@ -47,6 +47,7 @@ func init() {
 		"env":            argFunc0(nil),
 		"input":          argFunc0(nil),
 		"modulemeta":     argFunc0(nil),
+		"eval":           argFunc1(nil),
 		"length":         argFunc0(funcLength),
 		"utf8bytelength": argFunc0(funcUtf8ByteLength),
 		"keys":           argFunc0(funcKeys),


### PR DESCRIPTION
This is a proof of concept implementation for eval/1 function.

```sh
 % echo '{"x": 1}' | ./gojq 'eval(".x")'
1
 % echo '{"x": [1,2,3]}' | ./gojq -c 'eval([".", "..", ".x", ".x[]"][] | [tojson, .][])'
"."
{"x":[1,2,3]}
".."
{"x":[1,2,3]}
[1,2,3]
1
2
3
".x"
[1,2,3]
".x[]"
1
2
3
```

Resolves #38.
But capturing variables is not implemented and is too hard.