### PR TITLE
Fix YAML input at lower levels

### DIFF
--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -4904,6 +4904,22 @@
     }
     "bar"
 
+- name: yaml input option with non-string keys
+  args:
+    - --yaml-input
+    - '.'
+  input: |
+    foo:
+      - 42: bar
+  expected: |
+    {
+      "foo": [
+        {
+          "42": "bar"
+        }
+      ]
+    }
+
 - name: yaml input option with slurp option
   args:
     - --yaml-input

--- a/cli/yaml.go
+++ b/cli/yaml.go
@@ -12,6 +12,13 @@ func fixMapKeyToString(v interface{}) interface{} {
 		}
 		return w
 
+	case map[string]interface{}:
+		w := make(map[string]interface{}, len(v))
+		for k, v := range v {
+			w[k] = fixMapKeyToString(v)
+		}
+		return w
+
 	case []interface{}:
 		w := make([]interface{}, len(v))
 		for i := range v {


### PR DESCRIPTION
This improves the `fixMapKeyToString` workaround so that it works correctly when the YAML parser returns `map[string]interface{}` at the top level, but still returns `map[interface{}]interface{}` lower within the data structure.

This is an example of YAML input that would trigger the issue:

```yaml
string:
  1: number
```

Without the fix, running `gojq --yaml-input <test.yml`, I would get:

```
gojq: json: unsupported type: map[interface {}]interface {}
```

After handling the case of `map[string]interface{}` in `fixMapKeyToString` by recursing through its values, it is now working correctly:

```json
{
  "string": {
    "1": "number"
  }
}
```
