### PR TITLE
Add custom iterator function support which enables implementing a REPL in jq

### DIFF
--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/itchyny/gojq"
+)
+
+func read(c interface{}, a []interface{}) interface{} {
+	prompt, ok := a[0].(string)
+	if !ok {
+		return fmt.Errorf("%v: src is not a string", a[0])
+	}
+	fmt.Fprint(os.Stdout, prompt)
+	s := bufio.NewScanner(os.Stdin)
+	if ok = s.Scan(); !ok {
+		fmt.Fprintln(os.Stdout)
+		return io.EOF
+	}
+
+	return s.Text()
+}
+
+func eval(c interface{}, a []interface{}) interface{} {
+	src, ok := a[0].(string)
+	if !ok {
+		return fmt.Errorf("%v: src is not a string", a[0])
+	}
+	iter, err := replRun(c, src)
+	if err != nil {
+		return err
+	}
+
+	return iter
+}
+
+func print(c interface{}, a []interface{}) interface{} {
+	if _, err := fmt.Fprintln(os.Stdout, c); err != nil {
+		return err
+	}
+
+	return gojq.EmptyIter{}
+}
+
+func itertest(c interface{}, a []interface{}) interface{} {
+	return &gojq.SliceIter{Slice: []interface{}{1, 2, 3}}
+}
+
+func itererr(c interface{}, a []interface{}) interface{} {
+	return &gojq.SliceIter{Slice: []interface{}{1, fmt.Errorf("itervaluerr")}}
+}
+
+type preludeLoader struct{}
+
+func (preludeLoader) LoadInitModules() ([]*gojq.Query, error) {
+	replSrc := `
+def repl:
+	def _wrap: if (. | type) != "array" then [.] end;
+	def _repl:
+		try read("> ") as $e |
+		(try (.[] | eval($e)) catch . | print),
+		_repl;
+	_wrap | _repl;
+`
+	gq, err := gojq.Parse(replSrc)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*gojq.Query{gq}, nil
+}
+
+func replRun(c interface{}, src string) (gojq.Iter, error) {
+	gq, err := gojq.Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	gc, err := gojq.Compile(gq,
+		gojq.WithModuleLoader(preludeLoader{}),
+		gojq.WithFunction("read", 1, 1, read),
+		gojq.WithIterator("eval", 1, 1, eval),
+		gojq.WithIterator("print", 0, 0, print),
+
+		gojq.WithIterator("itertest", 0, 0, itertest),
+		gojq.WithIterator("itererr", 0, 0, itererr),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return gc.Run(c), nil
+}
+
+func main() {
+	expr := "repl"
+	if len(os.Args) > 1 {
+		expr = os.Args[1]
+	}
+	iter, err := replRun(nil, expr)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		} else if err, ok := v.(error); ok {
+			fmt.Fprintf(os.Stderr, "err: %v\n", err)
+			break
+		} else if d, ok := v.([2]interface{}); ok {
+			fmt.Fprintf(os.Stdout, "%s: %v\n", d[0], d[1])
+		}
+	}
+}

--- a/func.go
+++ b/func.go
@@ -30,6 +30,7 @@ const (
 type function struct {
 	argcount int
 	callback func(interface{}, []interface{}) interface{}
+	iterator bool
 }
 
 func (fn function) accept(cnt int) bool {
@@ -60,7 +61,7 @@ func init() {
 		"contains":       argFunc1(funcContains),
 		"explode":        argFunc0(funcExplode),
 		"implode":        argFunc0(funcImplode),
-		"split":          {argcount1 | argcount2, funcSplit},
+		"split":          {argcount1 | argcount2, funcSplit, false},
 		"tojson":         argFunc0(funcToJSON),
 		"fromjson":       argFunc0(funcFromJSON),
 		"format":         argFunc1(funcFormat),
@@ -172,9 +173,9 @@ func init() {
 		"strptime":       argFunc1(funcStrptime),
 		"now":            argFunc0(funcNow),
 		"_match":         argFunc3(funcMatch),
-		"error":          {argcount0 | argcount1, funcError},
+		"error":          {argcount0 | argcount1, funcError, false},
 		"halt":           argFunc0(funcHalt),
-		"halt_error":     {argcount0 | argcount1, funcHaltError},
+		"halt_error":     {argcount0 | argcount1, funcHaltError, false},
 		"_type_error":    argFunc1(internalfuncTypeError),
 	}
 }
@@ -184,6 +185,7 @@ func argFunc0(fn func(interface{}) interface{}) function {
 		argcount0, func(v interface{}, _ []interface{}) interface{} {
 			return fn(v)
 		},
+		false,
 	}
 }
 
@@ -192,6 +194,7 @@ func argFunc1(fn func(interface{}, interface{}) interface{}) function {
 		argcount1, func(v interface{}, args []interface{}) interface{} {
 			return fn(v, args[0])
 		},
+		false,
 	}
 }
 
@@ -200,6 +203,7 @@ func argFunc2(fn func(interface{}, interface{}, interface{}) interface{}) functi
 		argcount2, func(v interface{}, args []interface{}) interface{} {
 			return fn(v, args[0], args[1])
 		},
+		false,
 	}
 }
 
@@ -208,6 +212,7 @@ func argFunc3(fn func(interface{}, interface{}, interface{}, interface{}) interf
 		argcount3, func(v interface{}, args []interface{}) interface{} {
 			return fn(v, args[0], args[1], args[2])
 		},
+		false,
 	}
 }
 

--- a/iter.go
+++ b/iter.go
@@ -21,3 +21,28 @@ func (c *unitIter) Next() (interface{}, bool) {
 	}
 	return nil, false
 }
+
+// SliceIter is a Iter that iterate a interface{} slice from first to last value
+type SliceIter struct{ Slice []interface{} }
+
+// Next value in slice or no value if at end
+func (i *SliceIter) Next() (interface{}, bool) {
+	if len(i.Slice) == 0 {
+		return nil, false
+	}
+	e := i.Slice[0]
+	i.Slice = i.Slice[1:]
+	return e, true
+}
+
+// EmptyIter is a Iter that return no value, similar to "empty" keyword.
+type EmptyIter struct{}
+
+// Next returns no value
+func (EmptyIter) Next() (interface{}, bool) { return nil, false }
+
+// IterFn is a Iter that calls a provided next function
+type IterFn func() (interface{}, bool)
+
+// Next value in slice or no value if at end
+func (i IterFn) Next() (interface{}, bool) { return i() }

--- a/option_iterator_test.go
+++ b/option_iterator_test.go
@@ -1,0 +1,47 @@
+package gojq_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/itchyny/gojq"
+)
+
+func ExampleWithIterator() {
+	query, err := gojq.Parse("f | . * 2")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	code, err := gojq.Compile(
+		query,
+		gojq.WithIterator("f", 0, 0, func(x interface{}, xs []interface{}) interface{} {
+			i := 0
+			return gojq.IterFn(func() (interface{}, bool) {
+				if i > 2 {
+					return nil, false
+				}
+				i++
+				return i - 1, true
+			})
+		}),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	iter := code.Run(nil)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			log.Fatalln(err)
+		}
+		fmt.Printf("%#v\n", v)
+	}
+
+	// Output:
+	// 0
+	// 2
+	// 4
+}


### PR DESCRIPTION
Hi! this is more of a feature request than a PR but I choose to use a PR to show some proof of concept code.

Background is that i'm working on tool based on gojq that has a interactive CLI REPL interface. The REPL used to be implemented in go with quite a lot of messy code to make it "feel" like jq. Some days I realized that much of this could probably be solved if the REPL itself was written in jq.  After some thinking i realized that adding support for custom iterator functions would enable implementing `eval` as custom function.

With `read` and `print` as custom functions you can implement a REPL like this:
```jq
def repl:
	def _wrap: if (. | type) != "array" then [.] end;
	def _repl:
		try read("> ") as $e |
		(try (.[] | eval($e)) catch . | print),
		_repl;
	_wrap | _repl;
```

A bit more complicated than `def repl: read | eval(.) | print, repl; repl` to make it more user friendly.

Example usage showing basic expressions, nested REPL and errors:
```sh
$ go run cmd/repl/main.go
> 2+2
4
> 1 | repl
> .+2
3
> ^D
> [1,2,3] | repl
> .+10
11
12
13
> ^D
> 123
123
> undefined
function not defined: undefined/0
> [1,2,3] | repl
> undefined
function not defined: undefined/0
> ^D
> ^D
$
```

Some implementation notes:
- The `repl` takes an array as input and will array wrap non-array values. This feels natural but maybe there are better solutions?
- How to handle `1, 2, 3 | repl`. The current behavior to give multiple REPLs feels ok i think.
- Im unsure how to handle `env.paths` in `*env.Next()`. I guess it's related to assignment and `paths`? i haven't looked into how this could affect it.
- The code to implement the iterator can probably be much clear and nicer

What do you think? could be useful?