### PR TITLE
fix multiplying strings by infinite

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -378,7 +378,7 @@ func funcOpMul(_, l, r interface{}) interface{} {
 		deepMergeObjects,
 		func(l, r interface{}) interface{} {
 			multiplyString := func(s string, cnt float64) interface{} {
-				if cnt <= 0.0 || int(cnt) < 0 || int(cnt) > maxHalfInt/(16*(len(s)+1)) {
+				if cnt <= 0.0 || int(cnt) > maxHalfInt/(16*(len(s)+1)) || math.IsNaN(cnt-cnt) {
 					return nil
 				}
 				if cnt < 1.0 {


### PR DESCRIPTION
Relying on the result of int(math.Inf(1) is not correct as it's not
guaranteed to give an expected result, which depends on the platform.

mips64 (softfloat): 0
ppc64le: 9223372036854775807
s390x:   9223372036854775807
armv7:   9223372036854775807
aarch64: 9223372036854775807
x86_64:  -9223372036854775808

This caused a test failure on mips64, as the result of `"string" * 0` is
"" rather than the expected null.

So we cannot rely on the result of this being negative. Instead, check
whether it's either +/- infinity, or NaN. The quickest way to do that in
go is to check `math.IsNaN(n - n)`.

Fixes #69