### PR TITLE
use `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ brew install gojq
 
 ### Build from source
 ```sh
-go get github.com/itchyny/gojq/cmd/gojq
+go install github.com/itchyny/gojq/cmd/gojq@latest
 ```
 
 ### Docker


### PR DESCRIPTION
From Go1.17, installing commands using `go get` is deprecated.
https://tip.golang.org/doc/go1.17#go-get
`go install cmd@version` should be used instead.