### PR TITLE
add `//go:build` lines

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package gojq

--- a/release.go
+++ b/release.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package gojq


### PR DESCRIPTION
I added `//go:build` lines with `go1.17rc1 fmt`.
From Go 1.17, the go command understands the new syntax `//go:build`.
See https://golang.org/design/draft-gobuild