### PR TITLE
Fix combined --stream --slurp path slice reuse

### DIFF
--- a/cli/stream.go
+++ b/cli/stream.go
@@ -65,17 +65,17 @@ func (s *jsonStream) next() (interface{}, error) {
 				if s.states[len(s.states)-1] == jsonStateArrayStart {
 					s.states[len(s.states)-1] = jsonStateArrayEmptyEnd
 					s.path = s.path[:len(s.path)-1]
-					return []interface{}{s.path, []interface{}{}}, nil
+					return []interface{}{s.copyPath(), []interface{}{}}, nil
 				}
 				s.states[len(s.states)-1] = jsonStateArrayEnd
-				return []interface{}{s.path}, nil
+				return []interface{}{s.copyPath()}, nil
 			case '}':
 				if s.states[len(s.states)-1] == jsonStateObjectStart {
 					s.states[len(s.states)-1] = jsonStateObjectEmptyEnd
-					return []interface{}{s.path, map[string]interface{}{}}, nil
+					return []interface{}{s.copyPath(), map[string]interface{}{}}, nil
 				}
 				s.states[len(s.states)-1] = jsonStateObjectEnd
-				return []interface{}{s.path}, nil
+				return []interface{}{s.copyPath()}, nil
 			default:
 				panic(d)
 			}
@@ -85,17 +85,21 @@ func (s *jsonStream) next() (interface{}, error) {
 				s.states[len(s.states)-1] = jsonStateArrayValue
 				fallthrough
 			case jsonStateArrayValue:
-				return []interface{}{s.path, token}, nil
+				return []interface{}{s.copyPath(), token}, nil
 			case jsonStateObjectStart, jsonStateObjectValue:
 				s.states[len(s.states)-1] = jsonStateObjectKey
 				s.path = append(s.path, token)
 			case jsonStateObjectKey:
 				s.states[len(s.states)-1] = jsonStateObjectValue
-				return []interface{}{s.path, token}, nil
+				return []interface{}{s.copyPath(), token}, nil
 			default:
 				s.states[len(s.states)-1] = jsonStateTopValue
-				return []interface{}{s.path, token}, nil
+				return []interface{}{s.copyPath(), token}, nil
 			}
 		}
 	}
+}
+
+func (s *jsonStream) copyPath() []interface{} {
+	return append(make([]interface{}, 0, len(s.path)), s.path...)
 }

--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -5010,6 +5010,48 @@
       ]
     ]
 
+- name: stream and slurp option with objects
+  args:
+    - --stream
+    - --slurp
+  input: '{"a":1} {"b":2} {"c":3}'
+  expected: |
+    [
+      [
+        [
+          "a"
+        ],
+        1
+      ],
+      [
+        [
+          "a"
+        ]
+      ],
+      [
+        [
+          "b"
+        ],
+        2
+      ],
+      [
+        [
+          "b"
+        ]
+      ],
+      [
+        [
+          "c"
+        ],
+        3
+      ],
+      [
+        [
+          "c"
+        ]
+      ]
+    ]
+
 - name: inputs function with raw input option
   args:
     - -n


### PR DESCRIPTION
This fixes path reuse in jsonStream that affected combined `--stream`
and `--slurp` CLI options. Previously, when both `--stream` and
`--slurp` were passed to gojq, jsonStream's iterator would reuse its
internal path slice when returning the next path in iteration. This
resulted in all paths in the slurped input having the same path. This
has workarounds, like using `tostream` instead of `--stream --slurp`,
but still ends up being a bug around path reuse.

To fix it, this adds a copyPath method to jsonStream that returns a new
slice that is a shallow copy of the path slice (which is thankfully
made of up numbers and strings, so there's no need for any work to
clone its contents).

This includes an additional test case under test.yaml to cover the
combined `--stream --slurp` options.