### PR TITLE
improve quality of life when debugging invalid types

### DIFF
--- a/cli/encoder.go
+++ b/cli/encoder.go
@@ -56,7 +56,7 @@ func (e *encoder) encode(v interface{}) {
 	case map[string]interface{}:
 		e.encodeMap(v)
 	default:
-		panic(fmt.Sprintf("invalid value: %v", v))
+		panic(fmt.Sprintf("invalid type: %T (%v)", v, v))
 	}
 	if e.w.Len() > 8*1024 {
 		e.out.Write(e.w.Bytes())

--- a/encoder.go
+++ b/encoder.go
@@ -69,7 +69,7 @@ func (e *encoder) encode(v interface{}) {
 	case map[string]interface{}:
 		e.encodeMap(v)
 	default:
-		panic(fmt.Sprintf("invalid value: %v", v))
+		panic(fmt.Sprintf("invalid type: %T (%v)", v, v))
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -359,7 +359,7 @@ func typeof(v interface{}) string {
 	case map[string]interface{}:
 		return "object"
 	default:
-		panic(fmt.Sprintf("invalid value: %v", v))
+		panic(fmt.Sprintf("invalid type: %T (%v)", v, v))
 	}
 }
 


### PR DESCRIPTION
A headscratcher that came up while debugging a custom function. "invalid type: int64" should hopefully be a bit more clear than "invalid value: 3"

The panic in typeErrorPreview() was changed to an error string to avoid bizarre panic-while-panicking problems that can occur when calling panic(err), as panic would panic while trying to print the error.