### PR TITLE
add test for type/0 with invalid types

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -177,6 +177,22 @@ func TestQueryRun_IteratorError(t *testing.T) {
 	}
 }
 
+func TestQueryRun_TypePanic(t *testing.T) {
+	defer func() { recover() }()
+	query, err := gojq.Parse("type")
+	if err != nil {
+		t.Fatal(err)
+	}
+	iter := query.Run(struct{}{})
+	for {
+		_, ok := iter.Next()
+		if !ok {
+			break
+		}
+	}
+	t.Errorf("panic should occur")
+}
+
 func TestQueryRun_Strings(t *testing.T) {
 	query, err := gojq.Parse(
 		"[\"\x00\\\\\", \"\x1f\\\"\", \"\n\\n\n\\(\"\\n\")\n\\n\", " +


### PR DESCRIPTION
As per https://github.com/itchyny/gojq/pull/168#pullrequestreview-937185285 , `type/0` should panic on invalid types, so this commit documents that with a test case.

Incidentally, are there any objections to moving the panic in `typeof` into `funcType`? 