### PR TITLE
cli: Add Config.Run to set IO streams and args

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -55,12 +55,7 @@ func TestCliRun(t *testing.T) {
 					t.Fatal(err)
 				}
 			}()
-			var outStream, errStream strings.Builder
-			cli := cli{
-				inStream:  strings.NewReader(tc.Input),
-				outStream: &outStream,
-				errStream: &errStream,
-			}
+
 			for _, env := range tc.Env {
 				xs := strings.SplitN(env, "=", 2)
 				k, v := xs[0], xs[1]
@@ -78,7 +73,13 @@ func TestCliRun(t *testing.T) {
 				}
 				os.Setenv(k, v)
 			}
-			code := cli.run(tc.Args)
+
+			var outStream, errStream strings.Builder
+			code := (&Config{
+				Stdin:  strings.NewReader(tc.Input),
+				Stdout: &outStream,
+				Stderr: &errStream,
+			}).Run(tc.Args)
 			if tc.Error == "" {
 				if code != tc.ExitCode {
 					t.Errorf("exit code: got: %v, expected: %v", code, tc.ExitCode)

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,12 +1,50 @@
 package cli
 
-import "os"
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+// Config specifies configuration to run the gojq CLI with.
+type Config struct {
+	// Input and output streams for the CLI.
+	//
+	// If Stdin is nil, an empty stdin will be used.
+	// If Stdout or Stderr are nil, that output stream will be discarded.
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Run the gojq CLI with the provided arguments,
+// and return the exit code.
+//
+// The arguments must not contain os.Args[0].
+func (cfg *Config) Run(args []string) (exitCode int) {
+	cli := &cli{
+		inStream:  cfg.Stdin,
+		outStream: cfg.Stdout,
+		errStream: cfg.Stderr,
+	}
+	if cli.inStream == nil {
+		cli.inStream = bytes.NewReader(nil)
+	}
+	if cli.outStream == nil {
+		cli.outStream = io.Discard
+	}
+	if cli.errStream == nil {
+		cli.errStream = io.Discard
+	}
+
+	return cli.run(args)
+}
 
 // Run gojq.
 func Run() int {
-	return (&cli{
-		inStream:  os.Stdin,
-		outStream: os.Stdout,
-		errStream: os.Stderr,
-	}).run(os.Args[1:])
+	return (&Config{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}).Run(os.Args[1:])
 }

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func ExampleConfig() {
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader(`["foo", "bar", "baz"]`)
+	code := (&Config{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}).Run([]string{"-r", ". | .[]"})
+
+	if code != 0 {
+		log.Fatalf("exit code: got %v, expected: 0", code)
+	}
+
+	if stderr.Len() > 0 {
+		log.Fatalf("stderr: got %q, expected empty", stderr.String())
+	}
+
+	fmt.Print(stdout.String())
+
+	// Output:
+	// foo
+	// bar
+	// baz
+}
+
+func TestConfigStdin(t *testing.T) {
+	testCases := []struct {
+		name   string
+		stdin  io.Reader
+		output string
+	}{
+		{
+			name:   "set",
+			stdin:  strings.NewReader("{}"),
+			output: "{}\n",
+		},
+		{
+			name:   "unset",
+			stdin:  nil,
+			output: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			code := (&Config{
+				Stdin:  tc.stdin,
+				Stdout: &out,
+			}).Run([]string{"."})
+
+			if code != 0 {
+				t.Errorf("exit code: got %v, expected: 0", code)
+			}
+
+			if diff := cmp.Diff(tc.output, out.String()); diff != "" {
+				t.Error("standard output:\n" + diff)
+			}
+		})
+	}
+}
+
+func TestConfigStdoutUnset(t *testing.T) {
+	// When Stdout is unset, we need to make sure we don't write to
+	// os.Stdout.
+	// To test that, replace os.Stdout with a temporary file,
+	// and check that it's still empty after the program finishes.
+	defer func(stdout *os.File) {
+		os.Stdout = stdout
+	}(os.Stdout)
+	stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatalf("create temporary stdout: %v", err)
+	}
+	os.Stdout = stdout
+
+	code := (&Config{
+		Stdin: strings.NewReader("{}"),
+	}).Run([]string{"."})
+
+	if code != 0 {
+		t.Errorf("exit code: got %v, expected: 0", code)
+	}
+
+	if err := stdout.Close(); err != nil {
+		t.Fatalf("close temporary stdout: %v", err)
+	}
+
+	out, err := os.ReadFile(stdout.Name())
+	if err != nil {
+		t.Fatalf("read temporary stdout: %v", err)
+	}
+
+	if len(out) > 0 {
+		t.Errorf("expected os.Stdout to be empty, got %q", out)
+	}
+}
+
+func TestConfigStderrSet(t *testing.T) {
+	var stderr bytes.Buffer
+	code := (&Config{
+		Stderr: &stderr,
+	}).Run([]string{"--not-a-real-flag"})
+
+	if code == 0 {
+		t.Errorf("exit code: got %v, expected != 0", code)
+	}
+
+	if !strings.Contains(stderr.String(), "unknown flag") {
+		t.Errorf(`stderr output: must contain "unknown flag", got %q`, stderr.String())
+	}
+}
+
+func TestConfigStderrUnset(t *testing.T) {
+	// When Stderr is unset, we need to make sure we don't write to
+	// os.Stderr.
+	// To test that, replace os.Stderr with a temporary file,
+	// and check that it's still empty after the program finishes.
+	defer func(stderr *os.File) {
+		os.Stderr = stderr
+	}(os.Stderr)
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatalf("create temporary stderr: %v", err)
+	}
+	os.Stderr = stderr
+
+	code := new(Config).Run([]string{"--not-a-real-flag"})
+	if code == 0 {
+		t.Errorf("exit code: got %v, expected != 0", code)
+	}
+
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close temporary stderr: %v", err)
+	}
+
+	out, err := os.ReadFile(stderr.Name())
+	if err != nil {
+		t.Fatalf("read temporary stderr: %v", err)
+	}
+
+	if len(out) > 0 {
+		t.Errorf("expected os.Stderr to be empty, got %q", out)
+	}
+}


### PR DESCRIPTION
Adds a new Config type which allows setting Stdout, Stdin, and Stderr,
and a Config.Run method that accepts the command line arguments.

The new exported APIs are,

    package cli

    type Config struct {
      Stdin  io.Reader
      Stdout io.Writer
      Stderr io.Writer
    }

    func (cfg *Config) Run(args []string) (exitCode int)

These two combined are a version of cli.Run that does not rely on
the process' global IO streams, or on os.Args.

Testing:
This updates cli_test to use Config.Run instead of setting up the cli
struct, so this exercises Config.Run for all core test cases.
This also adds tests that verify the no-op behavior of each field of
Config.

Resolves #181
