### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/itchyny/gojq
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.4


### PR DESCRIPTION
Use Go 1.18 as the baseline as Go 1.17 is EOL. See https://endoflife.date/go