### PR TITLE
fix ordering of keys not being kept

### DIFF
--- a/cli/encoder.go
+++ b/cli/encoder.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strconv"
 	"unicode/utf8"
+
+	"github.com/cornelk/orderedmap"
 )
 
 type encoder struct {
@@ -55,6 +57,8 @@ func (e *encoder) encode(v interface{}) {
 		e.encodeArray(v)
 	case map[string]interface{}:
 		e.encodeMap(v)
+	case orderedmap.Entry:
+		e.encode(v.Value)
 	default:
 		panic(fmt.Sprintf("invalid type: %[1]T (%[1]v)", v))
 	}

--- a/cli/inputs.go
+++ b/cli/inputs.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cornelk/orderedmap"
 	"gopkg.in/yaml.v3"
 
 	"github.com/itchyny/gojq"
@@ -87,7 +88,7 @@ func (i *jsonInputIter) Next() (interface{}, bool) {
 	if i.err != nil {
 		return nil, false
 	}
-	var v interface{}
+	var v orderedmap.Map
 	if err := i.dec.Decode(&v); err != nil {
 		if err == io.EOF {
 			i.err = err

--- a/func.go
+++ b/func.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cornelk/orderedmap"
 	"github.com/itchyny/timefmt-go"
 )
 
@@ -379,6 +380,14 @@ func funcToEntries(v interface{}) interface{} {
 		for i, k := range keys(v) {
 			w[i] = map[string]interface{}{"key": k, "value": v[k]}
 		}
+		return w
+	case orderedmap.Map:
+		var w []interface{}
+		v.Range(func(key string, value interface{}) bool {
+			entry := map[string]interface{}{"key": key, "value": value}
+			w = append(w, entry)
+			return true
+		})
 		return w
 	default:
 		return &funcTypeError{"to_entries", v}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/itchyny/gojq
 go 1.17
 
 require (
+	github.com/cornelk/orderedmap v0.1.0
 	github.com/google/go-cmp v0.5.4
 	github.com/itchyny/timefmt-go v0.1.3
 	github.com/mattn/go-isatty v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cornelk/orderedmap v0.1.0 h1:9HBba89KR2eQ5Ji6PR5sQfpdJRwHL94GyLgibYebZtc=
+github.com/cornelk/orderedmap v0.1.0/go.mod h1:WepzZxxW89635HyC0rh3AhrPLWWEOH3f4XbCayxfEwI=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=


### PR DESCRIPTION
Closes #84

This PR adds a small dependency that allows the map key order to be kept.
The code changes needed to support this were small.
Only the shown example has been tested tho.

Before:

```
gojq -r 'to_entries[]' <<< '{"423":"abc","231":"dbh","352":"xyz"}'                                                                           main?
{
  "key": "231",
  "value": "dbh"
}
{
  "key": "352",
  "value": "xyz"
}
{
  "key": "423",
  "value": "abc"
}
```

using this fix:

```
gojq -r 'to_entries[]' <<< '{"423":"abc","231":"dbh","352":"xyz"}'                                                                          main!?
{
  "key": "423",
  "value": "abc"
}
{
  "key": "231",
  "value": "dbh"
}
{
  "key": "352",
  "value": "xyz"
}

```