### PR TITLE
short flags for --yaml-input and --yaml-output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -61,13 +61,13 @@ type flagopts struct {
 	OutputCompact bool              `short:"c" long:"compact-output" description:"output without pretty-printing"`
 	OutputIndent  *int              `long:"indent" description:"number of spaces for indentation"`
 	OutputTab     bool              `long:"tab" description:"use tabs for indentation"`
-	OutputYAML    bool              `long:"yaml-output" description:"output in YAML format"`
+	OutputYAML    bool              `short:"Y" long:"yaml-output" description:"output in YAML format"`
 	OutputColor   bool              `short:"C" long:"color-output" description:"output with colors even if piped"`
 	OutputMono    bool              `short:"M" long:"monochrome-output" description:"output without colors"`
 	InputNull     bool              `short:"n" long:"null-input" description:"use null as input value"`
 	InputRaw      bool              `short:"R" long:"raw-input" description:"read input as raw strings"`
 	InputStream   bool              `long:"stream" description:"parse input in stream fashion"`
-	InputYAML     bool              `long:"yaml-input" description:"read input as YAML format"`
+	InputYAML     bool              `short:"y" long:"yaml-input" description:"read input as YAML format"`
 	InputSlurp    bool              `short:"s" long:"slurp" description:"read all inputs into an array"`
 	FromFile      string            `short:"f" long:"from-file" description:"load query from file"`
 	ModulePaths   []string          `short:"L" description:"directory to search modules from"`


### PR DESCRIPTION
Add `-y` and `-Y` as short flags for `--yaml-input` and `--yaml-output`.