### PR TITLE
Add urid format string to decode URI values

### DIFF
--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -5906,6 +5906,22 @@
   expected: |
     "q=%5B%22%3C%3E%22%2C%22%7B%26%7D%22%5D&q=%5B%22%3C%3E%22%2C%22%7B%26%7D%22%2C%22%3C%3E%22%2C%22%7B%26%7D%22%5D"
 
+- name: format strings @urid
+  args:
+    - '@urid'
+  input: |
+    "%5B1%2C%7B%22foo%22%3A%22%3Cdiv%3E%26%27%5C%22%28%29%3C%2Fdiv%3E%22%7D%5D"
+  expected: |
+    "[1,{\"foo\":\"<div>&'\\\"()</div>\"}]"
+
+- name: format strings @urid error
+  args:
+    - '@urid'
+  input: |
+    "%5B1%2C%"
+  error: |
+    @urid cannot be applied: invalid URL escape "%"
+
 - name: format strings @csv
   args:
     - '@csv'

--- a/compiler.go
+++ b/compiler.go
@@ -1409,6 +1409,8 @@ func formatToFunc(format string) *Func {
 		return &Func{Name: "_tohtml"}
 	case "@uri":
 		return &Func{Name: "_touri"}
+	case "@urid":
+		return &Func{Name: "_tourid"}
 	case "@csv":
 		return &Func{Name: "_tocsv"}
 	case "@tsv":

--- a/func.go
+++ b/func.go
@@ -78,6 +78,7 @@ func init() {
 		"format":         argFunc1(funcFormat),
 		"_tohtml":        argFunc0(funcToHTML),
 		"_touri":         argFunc0(funcToURI),
+		"_tourid":        argFunc0(funcToURId),
 		"_tocsv":         argFunc0(funcToCSV),
 		"_totsv":         argFunc0(funcToTSV),
 		"_tosh":          argFunc0(funcToSh),
@@ -831,6 +832,19 @@ func funcToURI(v any) any {
 	switch x := funcToString(v).(type) {
 	case string:
 		return url.QueryEscape(x)
+	default:
+		return x
+	}
+}
+
+func funcToURId(v any) any {
+	switch x := funcToString(v).(type) {
+	case string:
+		escaped, err := url.QueryUnescape(x)
+		if err != nil {
+			return fmt.Errorf("@urid cannot be applied: %s", err.Error())
+		}
+		return string(escaped)
 	default:
 		return x
 	}


### PR DESCRIPTION
I noticed that while we have base64 encoding/decoding, jq can URI-encode but cannot URI-decode.

Given that it looks like gojq is open to making backwards-compatible improvements to jq, something like `@urid` would solve a use case I'm facing and provide parity with base64 encoding/decoding.