### PR TITLE
add xml support as xq (from python yq)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -332,7 +332,7 @@ func (cli *cli) createInputIter(args []string) (iter inputIter) {
 		newIter = newStreamInputIter
 	case cli.inputXML:
 		mxj.FixRoot(true)
-		mxj.ForceList(cli.forceListXML...)
+		mxj.ForceListForKeys(cli.forceListXML...)
 		mxj.KeepNamespace(cli.keepSpaceXML)
 		mxj.SetAttrPrefix("@")
 		newIter = newXMLInputIter

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -332,7 +332,13 @@ func (cli *cli) createInputIter(args []string) (iter inputIter) {
 		newIter = newStreamInputIter
 	case cli.inputXML:
 		mxj.FixRoot(true)
-		mxj.ForceListForKeys(cli.forceListXML...)
+		for _, s := range cli.forceListXML {
+			if strings.Contains(s, ".") {
+				mxj.ForceListForPaths(s)
+			} else {
+				mxj.ForceListForKeys(s)
+			}
+		}
 		mxj.KeepNamespace(cli.keepSpaceXML)
 		mxj.SetAttrPrefix("@")
 		newIter = newXMLInputIter

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -415,9 +415,6 @@ func (cli *cli) createMarshaler() marshaler {
 	if cli.outputYAML {
 		return yamlFormatter(cli.outputIndent)
 	}
-	if cli.outputXML {
-		return xmlFormatter(cli.outputIndent, cli.rootXML, cli.elementXML)
-	}
 	indent := 2
 	if cli.outputCompact {
 		indent = 0
@@ -425,6 +422,9 @@ func (cli *cli) createMarshaler() marshaler {
 		indent = 1
 	} else if i := cli.outputIndent; i != nil {
 		indent = *i
+	}
+	if cli.outputXML {
+		return xmlFormatter(&indent, cli.rootXML, cli.elementXML)
 	}
 	f := newEncoder(cli.outputTab, indent)
 	if cli.outputRaw || cli.outputJoin || cli.outputNul {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,7 +50,9 @@ type cli struct {
 	inputYAML     bool
 	inputSlurp    bool
 	stripSpaceXML bool
+	stripAttrsXML bool
 	forceListXML  []string
+	htmlXML       bool
 	rootXML       string
 	elementXML    string
 
@@ -76,10 +78,12 @@ type flagopts struct {
 	InputRaw      bool              `short:"R" long:"raw-input" description:"read input as raw strings"`
 	InputStream   bool              `long:"stream" description:"parse input in stream fashion"`
 	InputXML      bool              `short:"X" long:"xml-input" description:"read input as XML format"`
+	StripAttrsXML bool              `long:"xml-strip-attributes" description:"strip attributes from XML elements"`
 	StripSpaceXML bool              `long:"xml-strip-namespace" description:"strip namespace from XML elements and attributes"`
 	ForceListXML  []string          `long:"xml-force-list" description:"force XML elements as array"`
 	RootXML       string            `long:"xml-root" description:"root XML element name"`
 	ElementXML    string            `long:"xml-element" description:"element XML element name"`
+	HtmlXML       bool              `long:"xml-html" description:"HTML compatibility mode"`
 	InputYAML     bool              `short:"Y" long:"yaml-input" description:"read input as YAML format"`
 	InputSlurp    bool              `short:"s" long:"slurp" description:"read all inputs into an array"`
 	FromFile      string            `short:"f" long:"from-file" description:"load query from file"`
@@ -166,8 +170,8 @@ Usage:
 	}
 	cli.inputRaw, cli.inputStream, cli.inputYAML, cli.inputSlurp =
 		opts.InputRaw, opts.InputStream, opts.InputYAML, opts.InputSlurp
-	cli.inputXML, cli.stripSpaceXML, cli.forceListXML, cli.rootXML, cli.elementXML =
-		opts.InputXML, opts.StripSpaceXML, opts.ForceListXML, opts.RootXML, opts.ElementXML
+	cli.inputXML, cli.stripAttrsXML, cli.stripSpaceXML, cli.forceListXML, cli.rootXML, cli.elementXML, cli.htmlXML =
+		opts.InputXML, opts.StripAttrsXML, opts.StripSpaceXML, opts.ForceListXML, opts.RootXML, opts.ElementXML, opts.HtmlXML
 	for k, v := range opts.Arg {
 		cli.argnames = append(cli.argnames, "$"+k)
 		cli.argvalues = append(cli.argvalues, v)
@@ -331,7 +335,7 @@ func (cli *cli) createInputIter(args []string) (iter inputIter) {
 		newIter = newStreamInputIter
 	case cli.inputXML:
 		newIter = func(r io.Reader, fname string) inputIter {
-			return newXMLInputIter(r, fname, !cli.stripSpaceXML, cli.forceListXML)
+			return newXMLInputIter(r, fname, !cli.stripAttrsXML, !cli.stripSpaceXML, cli.forceListXML, cli.htmlXML)
 		}
 	case cli.inputYAML:
 		newIter = newYAMLInputIter

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -78,8 +78,8 @@ type flagopts struct {
 	InputRaw      bool              `short:"R" long:"raw-input" description:"read input as raw strings"`
 	InputStream   bool              `long:"stream" description:"parse input in stream fashion"`
 	InputXML      bool              `short:"X" long:"xml-input" description:"read input as XML format"`
-	StripAttrsXML bool              `long:"xml-strip-attributes" description:"strip attributes from XML elements"`
-	StripSpaceXML bool              `long:"xml-strip-namespace" description:"strip namespace from XML elements and attributes"`
+	StripAttrsXML bool              `long:"xml-no-attributes" description:"remove attributes from XML elements"`
+	StripSpaceXML bool              `long:"xml-no-namespaces" description:"remove namespace from XML elements and attributes"`
 	ForceListXML  []string          `long:"xml-force-list" description:"force XML elements as array"`
 	RootXML       string            `long:"xml-root" description:"root XML element name"`
 	ElementXML    string            `long:"xml-element" description:"element XML element name"`

--- a/cli/inputs.go
+++ b/cli/inputs.go
@@ -11,8 +11,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/clbanning/mxj/v2"
 	"github.com/itchyny/gojq"
+	"github.com/momiji/xqml"
 )
 
 type inputReader struct {
@@ -309,30 +309,35 @@ func (i *streamInputIter) Name() string {
 
 type xmlInputIter struct {
 	dec   *xml.Decoder
+	xq    *xqml.Xqml
 	ir    *inputReader
 	fname string
 	err   error
 }
 
-func newXMLInputIter(r io.Reader, fname string) inputIter {
+func newXMLInputIter(r io.Reader, fname string, namespace bool, forceList []string) inputIter {
 	ir := newInputReader(r)
 	dec := xml.NewDecoder(ir)
 	dec.Strict = false
-	return &xmlInputIter{dec: dec, ir: ir, fname: fname}
+	//dec.AutoClose = xml.HTMLAutoClose
+	dec.Entity = xml.HTMLEntity
+	xq := xqml.NewXQML()
+	xq.Decoder(dec)
+	xq.Partial(true)
+	xq.Namespace(namespace)
+	xq.ForceList(forceList...)
+	return &xmlInputIter{dec: dec, xq: xq, ir: ir, fname: fname}
 }
 
 func (i *xmlInputIter) Next() (any, bool) {
 	if i.err != nil {
 		return nil, false
 	}
-	mxj.CustomDecoder = i.dec
-	m, err := mxj.NewMapXmlReader(i.ir, true)
+	m, err := i.xq.ParseXml(i.ir, true)
 	if err != nil {
 		return nil, false
 	}
-	var v map[string]interface{}
-	v = m
-	return v, true
+	return m, true
 }
 
 func (i *xmlInputIter) Close() error {

--- a/cli/inputs.go
+++ b/cli/inputs.go
@@ -315,17 +315,21 @@ type xmlInputIter struct {
 	err   error
 }
 
-func newXMLInputIter(r io.Reader, fname string, namespace bool, forceList []string) inputIter {
+func newXMLInputIter(r io.Reader, fname string, attributes bool, namespace bool, forceList []string, html bool) inputIter {
 	ir := newInputReader(r)
 	dec := xml.NewDecoder(ir)
 	dec.Strict = false
-	//dec.AutoClose = xml.HTMLAutoClose
 	dec.Entity = xml.HTMLEntity
+	if html {
+		dec.AutoClose = xml.HTMLAutoClose
+	}
 	xq := xqml.NewXQML()
 	xq.Decoder(dec)
 	xq.Partial(true)
+	xq.Attributes(attributes)
 	xq.Namespace(namespace)
 	xq.ForceList(forceList...)
+	xq.Html(html)
 	return &xmlInputIter{dec: dec, xq: xq, ir: ir, fname: fname}
 }
 

--- a/cli/marshaler.go
+++ b/cli/marshaler.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"github.com/clbanning/mxj/v2"
+	"github.com/momiji/xqml"
 	"io"
 	"strings"
 
@@ -35,29 +35,18 @@ type xmlMarshaller struct {
 }
 
 func (m *xmlMarshaller) marshal(v any, w io.Writer) error {
-	indentStr := "  "
+	xq := xqml.NewXQML()
 	if i := m.indent; i != nil {
-		indentStr = strings.Repeat(" ", *m.indent)
+		indentStr := strings.Repeat(" ", *m.indent)
+		xq.Indent(indentStr)
 	}
-	tags := []string{m.root, m.element}
-	if m.root == "" {
-		tags[0] = mxj.DefaultRootTag
+	if m.root != "" {
+		xq.Root(m.root)
 	}
-	if m.element == "" {
-		tags[1] = mxj.DefaultElementTag
+	if m.element != "" {
+		xq.Element(m.element)
 	}
-	var bytes []byte
-	var err error
-	if indentStr == "" {
-		bytes, err = mxj.AnyXml(v, tags...)
-	} else {
-		bytes, err = mxj.AnyXmlIndent(v, "", indentStr, tags...)
-	}
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(bytes)
-	return err
+	return xq.WriteXml(w, v)
 }
 
 func yamlFormatter(indent *int) *yamlMarshaler {

--- a/cli/marshaler.go
+++ b/cli/marshaler.go
@@ -49,7 +49,7 @@ func (m *xmlMarshaller) marshal(v any, w io.Writer) error {
 	var bytes []byte
 	var err error
 	if indentStr == "" {
-		bytes, err = mxj.AnyXml(v)
+		bytes, err = mxj.AnyXml(v, tags...)
 	} else {
 		bytes, err = mxj.AnyXmlIndent(v, "", indentStr, tags...)
 	}

--- a/cli/marshaler.go
+++ b/cli/marshaler.go
@@ -46,7 +46,13 @@ func (m *xmlMarshaller) marshal(v any, w io.Writer) error {
 	if m.element == "" {
 		tags[1] = mxj.DefaultElementTag
 	}
-	bytes, err := mxj.AnyXmlIndent(v, "", indentStr, tags...)
+	var bytes []byte
+	var err error
+	if indentStr == "" {
+		bytes, err = mxj.AnyXml(v)
+	} else {
+		bytes, err = mxj.AnyXmlIndent(v, "", indentStr, tags...)
+	}
 	if err != nil {
 		return err
 	}

--- a/cli/marshaler.go
+++ b/cli/marshaler.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"github.com/clbanning/mxj/v2"
 	"io"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,6 +22,36 @@ func (m *rawMarshaler) marshal(v any, w io.Writer) error {
 		return err
 	}
 	return m.m.marshal(v, w)
+}
+
+func xmlFormatter(indent *int, root string, element string) *xmlMarshaller {
+	return &xmlMarshaller{indent, root, element}
+}
+
+type xmlMarshaller struct {
+	indent  *int
+	root    string
+	element string
+}
+
+func (m *xmlMarshaller) marshal(v any, w io.Writer) error {
+	indentStr := "  "
+	if i := m.indent; i != nil {
+		indentStr = strings.Repeat(" ", *m.indent)
+	}
+	tags := []string{m.root, m.element}
+	if m.root == "" {
+		tags[0] = mxj.DefaultRootTag
+	}
+	if m.element == "" {
+		tags[1] = mxj.DefaultElementTag
+	}
+	bytes, err := mxj.AnyXmlIndent(v, "", indentStr, tags...)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(bytes)
+	return err
 }
 
 func yamlFormatter(indent *int) *yamlMarshaler {

--- a/cli/testdata/1.xml
+++ b/cli/testdata/1.xml
@@ -1,0 +1,6 @@
+<foo ns:x="1">
+    <bar>42</bar>
+    <baz>
+    </baz>
+    <qux>100</qux>
+</foo>

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/itchyny/gojq
 
 go 1.18
 
-replace github.com/clbanning/mxj/v2 v2.5.7 => github.com/momiji/mxj/v2 v2.7.0-x1
+replace github.com/clbanning/mxj/v2 v2.5.7 => github.com/momiji/mxj/v2 v2.7.0-x2
 
 require (
 	github.com/clbanning/mxj/v2 v2.5.7

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/itchyny/gojq
 
 go 1.18
 
+replace github.com/clbanning/mxj/v2 v2.5.7 => github.com/momiji/mxj/v2 v2.7.0-x1
+
 require (
+	github.com/clbanning/mxj/v2 v2.5.7
 	github.com/google/go-cmp v0.5.4
 	github.com/itchyny/timefmt-go v0.1.5
 	github.com/mattn/go-isatty v0.0.19

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/itchyny/gojq
 
 go 1.18
 
-replace github.com/clbanning/mxj/v2 v2.5.7 => github.com/momiji/mxj/v2 v2.7.0-x2
+replace github.com/clbanning/mxj/v2 v2.5.7 => github.com/momiji/mxj/v2 v2.7.0-x3
 
 require (
 	github.com/clbanning/mxj/v2 v2.5.7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.5
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mattn/go-runewidth v0.0.14
-	github.com/momiji/xqml v0.0.1
+	github.com/momiji/xqml v0.0.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,12 @@ module github.com/itchyny/gojq
 
 go 1.18
 
-replace github.com/clbanning/mxj/v2 v2.5.7 => github.com/momiji/mxj/v2 v2.7.0-x3
-
 require (
-	github.com/clbanning/mxj/v2 v2.5.7
 	github.com/google/go-cmp v0.5.4
 	github.com/itchyny/timefmt-go v0.1.5
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mattn/go-runewidth v0.0.14
+	github.com/momiji/xqml v0.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.5
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mattn/go-runewidth v0.0.14
-	github.com/momiji/xqml v0.0.0
+	github.com/momiji/xqml v0.0.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/momiji/mxj/v2 v2.7.0-x1 h1:mZi8TWzMZrNe6oZqdOpksQhhv7BiuoNlTL6b4Rut3Ug=
-github.com/momiji/mxj/v2 v2.7.0-x1/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
+github.com/momiji/mxj/v2 v2.7.0-x2 h1:qzomqioNVB0Sf0ffZxWqEmx7B07N6HSLuRzVmoeC23M=
+github.com/momiji/mxj/v2 v2.7.0-x2/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/momiji/xqml v0.0.0 h1:MxyO3DMwM2DoSNhvobD/e8jQlofWlRO2fu8TYzO/t2g=
-github.com/momiji/xqml v0.0.0/go.mod h1:IrROwWeq3LeqxsOtamTWx6L39irg7HJrH7GuDNolSv0=
+github.com/momiji/xqml v0.0.1 h1:bZ9WgPkyKqfWYeW/UbVozGL0Rq5eDm23G8QCCJLvpvM=
+github.com/momiji/xqml v0.0.1/go.mod h1:IrROwWeq3LeqxsOtamTWx6L39irg7HJrH7GuDNolSv0=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/momiji/xqml v0.0.1 h1:bZ9WgPkyKqfWYeW/UbVozGL0Rq5eDm23G8QCCJLvpvM=
-github.com/momiji/xqml v0.0.1/go.mod h1:IrROwWeq3LeqxsOtamTWx6L39irg7HJrH7GuDNolSv0=
+github.com/momiji/xqml v0.0.2 h1:zCKvrQx/DXTOTSl5+yNREk24NZv5F7vgpVchJOkH1Ws=
+github.com/momiji/xqml v0.0.2/go.mod h1:IrROwWeq3LeqxsOtamTWx6L39irg7HJrH7GuDNolSv0=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/momiji/mxj/v2 v2.7.0-x2 h1:qzomqioNVB0Sf0ffZxWqEmx7B07N6HSLuRzVmoeC23M=
-github.com/momiji/mxj/v2 v2.7.0-x2/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
+github.com/momiji/xqml v0.0.0 h1:MxyO3DMwM2DoSNhvobD/e8jQlofWlRO2fu8TYzO/t2g=
+github.com/momiji/xqml v0.0.0/go.mod h1:IrROwWeq3LeqxsOtamTWx6L39irg7HJrH7GuDNolSv0=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/momiji/mxj/v2 v2.7.0-x1 h1:mZi8TWzMZrNe6oZqdOpksQhhv7BiuoNlTL6b4Rut3Ug=
+github.com/momiji/mxj/v2 v2.7.0-x1/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
The idea it to add xml support the same as xq (installed with python yq).
It supports multiple xml inputs, that xq does not allow.

On read, much faster than original xq.
On write, many times faster than json2xml.

I'm opened to ideas.