### PR TITLE
fix(cli): update cli flags to match jq 1.7

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -57,17 +57,17 @@ type cli struct {
 type flagopts struct {
 	OutputRaw     bool              `short:"r" long:"raw-output" description:"output raw strings"`
 	OutputJoin    bool              `short:"j" long:"join-output" description:"output without newlines"`
-	OutputNul     bool              `short:"0" long:"nul-output" description:"output with NUL character"`
+	OutputNul     bool              `long:"raw-output0" description:"output with NUL character"`
 	OutputCompact bool              `short:"c" long:"compact-output" description:"output without pretty-printing"`
 	OutputIndent  *int              `long:"indent" description:"number of spaces for indentation"`
 	OutputTab     bool              `long:"tab" description:"use tabs for indentation"`
-	OutputYAML    bool              `long:"yaml-output" description:"output in YAML format"`
+	OutputYAML    bool              `long:"yaml-output" description:"output in YAML format (gojq only)"`
 	OutputColor   bool              `short:"C" long:"color-output" description:"output with colors even if piped"`
 	OutputMono    bool              `short:"M" long:"monochrome-output" description:"output without colors"`
 	InputNull     bool              `short:"n" long:"null-input" description:"use null as input value"`
 	InputRaw      bool              `short:"R" long:"raw-input" description:"read input as raw strings"`
 	InputStream   bool              `long:"stream" description:"parse input in stream fashion"`
-	InputYAML     bool              `long:"yaml-input" description:"read input as YAML format"`
+	InputYAML     bool              `long:"yaml-input" description:"read input as YAML format (gojq only)"`
 	InputSlurp    bool              `short:"s" long:"slurp" description:"read all inputs into an array"`
 	FromFile      string            `short:"f" long:"from-file" description:"load query from file"`
 	ModulePaths   []string          `short:"L" description:"directory to search modules from"`
@@ -78,7 +78,7 @@ type flagopts struct {
 	Args          []any             `long:"args" positional:"" description:"consume remaining arguments as positional string values"`
 	JSONArgs      []any             `long:"jsonargs" positional:"" description:"consume remaining arguments as positional JSON values"`
 	ExitStatus    bool              `short:"e" long:"exit-status" description:"exit 1 when the last value is false or null"`
-	Version       bool              `short:"v" long:"version" description:"display version information"`
+	Version       bool              `short:"V" long:"version" description:"display version information"`
 	Help          bool              `short:"h" long:"help" description:"display this help information"`
 }
 

--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -6247,26 +6247,46 @@
   input: '["foo",[{},{}],1,[2,3]]'
   expected: "foo[\n  {},\n  {}\n]1[\n  2,\n  3\n]"
 
-- name: nul output option
+- name: nul output option legacy
   args:
     - '-0'
     - '.[]'
   input: '["foo",1,2,3]'
-  expected: "foo\x001\x002\x003\x00"
+  error: |
+    open .[]: no such file or directory
+  exit_code: 5
 
 - name: nul output long option
   args:
-    - --nul-output
+    - --raw-output0
     - '.[]'
   input: '["foo",[{},{}],1,[2,3]]'
   expected: "foo\x00[\n  {},\n  {}\n]\x001\x00[\n  2,\n  3\n]\x00"
 
+- name: nul output long option legacy
+  args:
+    - --nul-output
+    - '.[]'
+  input: '["foo",[{},{}],1,[2,3]]'
+  error: |
+    unknown flag `--nul-output'
+  exit_code: 2
+
 - name: nul output option at the last argument
+  args:
+    - '.[]'
+    - '--raw-output0'
+  input: '["foo",1,2,3]'
+  expected: "foo\x001\x002\x003\x00"
+
+- name: nul output option at the last argument legacy
   args:
     - '.[]'
     - '-0'
   input: '["foo",1,2,3]'
-  expected: "foo\x001\x002\x003\x00"
+  error: |
+    open -0: no such file or directory
+  exit_code: 5
 
 - name: color output option
   args:
@@ -8117,11 +8137,21 @@
 
 - name: double dash with nul output option
   args:
-    - '-0'
+    - '--raw-output0'
     - '--'
     - '-0'
   input: '1'
   expected: "0\x00"
+
+- name: double dash with nul output option legacy
+  args:
+    - '-0'
+    - '--'
+    - '-0'
+  input: '1'
+  error: |
+    open -0: no such file or directory
+  exit_code: 5
 
 - name: double double dash
   args:


### PR DESCRIPTION
the `gojq` CLI has some differences in flags compared to the current
release of `jq`.  some are clearly intentional, such as `--yaml-output`,
but others are different in name but not in behavior, which can prevent
`gojq` from being a drop-in replacement for `jq` in scripts.

this PR updates CLI flags to match `jq` 1.7.
