### PR TITLE
Support concurrency / improved performance for multiple queries on same JSON payload

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -50,12 +50,6 @@ func (c *Code) RunWithContext(ctx context.Context, v any, values ...any) Iter {
 	return c.ConcurrentRunWithContext(ctx, PrepareData(v), normalized...)
 }
 
-// PrepareData is not safe for use in goroutines, since it writes to any maps
-// with numeric values; supports ConcurrentRun and ConcurrentRunWithContext.
-func PrepareData(v any) PreparedData {
-	return normalizeNumbers(v)
-}
-
 // ConcurrentRun supports reusing data across goroutines, as long as it is
 // prepared with PrepareData.
 func (c *Code) ConcurrentRun(v PreparedData, values ...any) Iter {

--- a/compiler.go
+++ b/compiler.go
@@ -43,7 +43,7 @@ func (c *Code) Run(v any, values ...any) Iter {
 // RunWithContext runs the code with context.
 // Alternatively, see PrepareData and ConcurrentRunWithContext.
 func (c *Code) RunWithContext(ctx context.Context, v any, values ...any) Iter {
-	normalized := make([]preparedData, len(values))
+	normalized := make([]PreparedData, len(values))
 	for i, v := range values {
 		normalized[i] = PrepareData(v)
 	}
@@ -52,18 +52,18 @@ func (c *Code) RunWithContext(ctx context.Context, v any, values ...any) Iter {
 
 // PrepareData is not safe for use in goroutines, since it writes to any maps
 // with numeric values; supports ConcurrentRun and ConcurrentRunWithContext.
-func PrepareData(v any) preparedData {
+func PrepareData(v any) PreparedData {
 	return normalizeNumbers(v)
 }
 
 // ConcurrentRun supports reusing data across goroutines, as long as it is
 // prepared with PrepareData.
-func (c *Code) ConcurrentRun(v preparedData, values ...any) Iter {
+func (c *Code) ConcurrentRun(v PreparedData, values ...any) Iter {
 	return c.ConcurrentRunWithContext(context.Background(), v, values)
 }
 
 // ConcurrentRunWithContext runs the code concurrently with context.
-func (c *Code) ConcurrentRunWithContext(ctx context.Context, v preparedData, values ...preparedData) Iter {
+func (c *Code) ConcurrentRunWithContext(ctx context.Context, v PreparedData, values ...PreparedData) Iter {
 	if len(values) > len(c.variables) {
 		return NewIter(&tooManyVariableValuesError{})
 	} else if len(values) < len(c.variables) {

--- a/execute.go
+++ b/execute.go
@@ -7,7 +7,10 @@ import (
 	"sort"
 )
 
-func (env *env) execute(bc *Code, v any, vars ...any) Iter {
+// preparedData will have gone through normalizeNumbers
+type preparedData any
+
+func (env *env) execute(bc *Code, v preparedData, vars ...preparedData) Iter {
 	env.codes = bc.codes
 	env.codeinfos = bc.codeinfos
 	env.push(v)

--- a/execute.go
+++ b/execute.go
@@ -7,10 +7,10 @@ import (
 	"sort"
 )
 
-// preparedData will have gone through normalizeNumbers
-type preparedData any
+// PreparedData will have gone through normalizeNumbers.
+type PreparedData any
 
-func (env *env) execute(bc *Code, v preparedData, vars ...preparedData) Iter {
+func (env *env) execute(bc *Code, v PreparedData, vars ...PreparedData) Iter {
 	env.codes = bc.codes
 	env.codeinfos = bc.codeinfos
 	env.push(v)

--- a/normalize.go
+++ b/normalize.go
@@ -7,6 +7,12 @@ import (
 	"strings"
 )
 
+// PrepareData is not safe for use in goroutines, since it writes to any maps
+// with numeric values; supports ConcurrentRun and ConcurrentRunWithContext.
+func PrepareData(v any) PreparedData {
+	return normalizeNumbers(v)
+}
+
 func normalizeNumber(v json.Number) any {
 	if i, err := v.Int64(); err == nil && math.MinInt <= i && i <= math.MaxInt {
 		return int(i)

--- a/normalize.go
+++ b/normalize.go
@@ -25,7 +25,7 @@ func normalizeNumber(v json.Number) any {
 	return math.Inf(1)
 }
 
-func normalizeNumbers(v any) any {
+func normalizeNumbers(v any) PreparedData {
 	switch v := v.(type) {
 	case json.Number:
 		return normalizeNumber(v)

--- a/query.go
+++ b/query.go
@@ -34,6 +34,21 @@ func (e *Query) RunWithContext(ctx context.Context, v any) Iter {
 	return code.RunWithContext(ctx, v)
 }
 
+// ConcurrentRun supports reusing data across goroutines, as long as it is
+// prepared with PrepareData.
+func (e *Query) ConcurrentRun(v PreparedData) Iter {
+	return e.ConcurrentRunWithContext(context.Background(), v)
+}
+
+// ConcurrentRunWithContext runs the code concurrently with context.
+func (e *Query) ConcurrentRunWithContext(ctx context.Context, v PreparedData) Iter {
+	code, err := Compile(e)
+	if err != nil {
+		return NewIter(err)
+	}
+	return code.ConcurrentRunWithContext(ctx, v)
+}
+
 func (e *Query) String() string {
 	var s strings.Builder
 	e.writeTo(&s)


### PR DESCRIPTION
RE: https://github.com/itchyny/gojq/issues/236

I don't love the naming decisions of this implementation, but the main idea is that I needed a way to run normalize numbers once for a JSON payload. Should also be backwards compatible with existing functions.

For an example implementation: https://github.com/samsullivan/jqless/pull/3