### PR TITLE
cli: option -k to preserve the order of keys

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,6 +49,9 @@ type cli struct {
 	argnames  []string
 	argvalues []any
 
+	keys    map[uintptr][]string
+	cliOpts []cliOption
+
 	outputYAMLSeparator bool
 	exitCodeError       error
 }
@@ -76,9 +79,22 @@ type flagopts struct {
 	RawFile       map[string]string `long:"rawfile" description:"set the contents of a file to a variable"`
 	Args          []any             `long:"args" positional:"" description:"consume remaining arguments as positional string values"`
 	JSONArgs      []any             `long:"jsonargs" positional:"" description:"consume remaining arguments as positional JSON values"`
+	KeyOrder      bool              `short:"k" long:"key-order" description:"preserve order of keys"`
 	ExitStatus    bool              `short:"e" long:"exit-status" description:"exit 1 when the last value is false or null"`
 	Version       bool              `short:"v" long:"version" description:"display version information"`
 	Help          bool              `short:"h" long:"help" description:"display this help information"`
+}
+
+type cliConfig struct {
+	keys map[uintptr][]string
+}
+
+type cliOption func(*cliConfig)
+
+func withKeys(keys map[uintptr][]string) cliOption {
+	return func(c *cliConfig) {
+		c.keys = keys
+	}
 }
 
 var addDefaultModulePaths = true
@@ -124,6 +140,12 @@ Usage:
 		cli.outputCompact, cli.outputIndent, cli.outputTab, cli.outputYAML =
 		opts.OutputRaw, opts.OutputRaw0, opts.OutputJoin,
 		opts.OutputCompact, opts.OutputIndent, opts.OutputTab, opts.OutputYAML
+
+	if opts.KeyOrder {
+		cli.keys = map[uintptr][]string{}
+		cli.cliOpts = append(cli.cliOpts, withKeys(cli.keys))
+	}
+
 	defer func(x bool) { noColor = x }(noColor)
 	if opts.OutputColor || opts.OutputMono {
 		noColor = opts.OutputMono
@@ -157,7 +179,7 @@ Usage:
 		cli.argvalues = append(cli.argvalues, v)
 	}
 	for k, v := range opts.ArgJSON {
-		val, _ := newJSONInputIter(strings.NewReader(v), "$"+k).Next()
+		val, _ := newJSONInputIter(strings.NewReader(v), "$"+k, cli.cliOpts...).Next()
 		if err, ok := val.(error); ok {
 			return err
 		}
@@ -165,7 +187,7 @@ Usage:
 		cli.argvalues = append(cli.argvalues, val)
 	}
 	for k, v := range opts.SlurpFile {
-		val, err := slurpFile(v)
+		val, err := slurpFile(v, cli.cliOpts...)
 		if err != nil {
 			return err
 		}
@@ -187,7 +209,7 @@ Usage:
 	positional := opts.Args
 	for i, v := range opts.JSONArgs {
 		if v != nil {
-			val, _ := newJSONInputIter(strings.NewReader(v.(string)), "--jsonargs").Next()
+			val, _ := newJSONInputIter(strings.NewReader(v.(string)), "--jsonargs", cli.cliOpts...).Next()
 			if err, ok := val.(error); ok {
 				return err
 			}
@@ -234,7 +256,7 @@ Usage:
 	if len(modulePaths) == 0 && addDefaultModulePaths {
 		modulePaths = []string{"~/.jq", "$ORIGIN/../lib/gojq", "$ORIGIN/../lib"}
 	}
-	iter := cli.createInputIter(args)
+	iter := cli.createInputIter(args, cli.cliOpts...)
 	defer iter.Close()
 	code, err := gojq.Compile(query,
 		gojq.WithModuleLoader(gojq.NewModuleLoader(modulePaths)),
@@ -275,9 +297,9 @@ Usage:
 	return cli.process(iter, code)
 }
 
-func slurpFile(name string) (any, error) {
+func slurpFile(name string, opts ...cliOption) (any, error) {
 	iter := newSlurpInputIter(
-		newFilesInputIter(newJSONInputIter, []string{name}, nil),
+		newFilesInputIter(newJSONInputIter, []string{name}, nil, opts...),
 	)
 	defer iter.Close()
 	val, _ := iter.Next()
@@ -287,8 +309,8 @@ func slurpFile(name string) (any, error) {
 	return val, nil
 }
 
-func (cli *cli) createInputIter(args []string) (iter inputIter) {
-	var newIter func(io.Reader, string) inputIter
+func (cli *cli) createInputIter(args []string, opts ...cliOption) (iter inputIter) {
+	var newIter func(io.Reader, string, ...cliOption) inputIter
 	switch {
 	case cli.inputRaw:
 		if cli.inputSlurp {
@@ -313,9 +335,9 @@ func (cli *cli) createInputIter(args []string) (iter inputIter) {
 		}()
 	}
 	if len(args) == 0 {
-		return newIter(cli.inStream, "<stdin>")
+		return newIter(cli.inStream, "<stdin>", cli.cliOpts...)
 	}
-	return newFilesInputIter(newIter, args, cli.inStream)
+	return newFilesInputIter(newIter, args, cli.inStream, opts...)
 }
 
 func (cli *cli) process(iter inputIter, code *gojq.Code) error {
@@ -375,7 +397,7 @@ func (cli *cli) printValues(iter gojq.Iter) error {
 
 func (cli *cli) createMarshaler() marshaler {
 	if cli.outputYAML {
-		return yamlFormatter(cli.outputIndent)
+		return yamlFormatter(cli.outputIndent, cli.cliOpts...)
 	}
 	indent := 2
 	if cli.outputCompact {
@@ -385,7 +407,7 @@ func (cli *cli) createMarshaler() marshaler {
 	} else if i := cli.outputIndent; i != nil {
 		indent = *i
 	}
-	f := newEncoder(cli.outputTab, indent)
+	f := newEncoder(cli.outputTab, indent, cli.cliOpts...)
 	if cli.outputRaw || cli.outputRaw0 || cli.outputJoin {
 		return &rawMarshaler{f, cli.outputRaw0}
 	}
@@ -393,7 +415,7 @@ func (cli *cli) createMarshaler() marshaler {
 }
 
 func (cli *cli) funcDebug(v any, _ []any) any {
-	if err := newEncoder(false, 0).
+	if err := newEncoder(false, 0, cli.cliOpts...).
 		marshal([]any{"DEBUG:", v}, cli.errStream); err != nil {
 		return err
 	}
@@ -404,7 +426,7 @@ func (cli *cli) funcDebug(v any, _ []any) any {
 }
 
 func (cli *cli) funcStderr(v any, _ []any) any {
-	if err := (&rawMarshaler{m: newEncoder(false, 0)}).
+	if err := (&rawMarshaler{m: newEncoder(false, 0, cli.cliOpts...)}).
 		marshal(v, cli.errStream); err != nil {
 		return err
 	}

--- a/cli/key_order.go
+++ b/cli/key_order.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"gopkg.in/yaml.v3"
+)
+
+type anyWithOrderedKeys struct {
+	m *orderedmap.OrderedMap[string, anyWithOrderedKeys]
+	l []anyWithOrderedKeys
+	v any
+}
+
+func (v *anyWithOrderedKeys) UnmarshalJSON(data []byte) error {
+	data1 := bytes.TrimSpace(data)
+	if len(data1) == 0 {
+		return fmt.Errorf("empty JSON")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	switch data1[0] {
+	case '{':
+		v.m = orderedmap.New[string, anyWithOrderedKeys]()
+		return dec.Decode(&v.m)
+	case '[':
+		v.l = []anyWithOrderedKeys{}
+		return dec.Decode(&v.l)
+	}
+
+	return dec.Decode(&v.v)
+}
+
+func (v *anyWithOrderedKeys) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.MappingNode:
+		v.m = orderedmap.New[string, anyWithOrderedKeys]()
+		return value.Decode(&v.m)
+	case yaml.SequenceNode:
+		v.l = []anyWithOrderedKeys{}
+		return value.Decode(&v.l)
+	}
+
+	return value.Decode(&v.v)
+}
+
+func (v anyWithOrderedKeys) unwrap(keys map[uintptr][]string) any {
+	switch {
+	case v.m != nil:
+		m := make(map[string]any, v.m.Len())
+		keyList := make([]string, 0, v.m.Len())
+		for pair := v.m.Oldest(); pair != nil; pair = pair.Next() {
+			keyList = append(keyList, pair.Key)
+			m[pair.Key] = pair.Value.unwrap(keys)
+		}
+		ptr := uintptr(reflect.ValueOf(m).UnsafePointer())
+		keys[ptr] = keyList
+		return m
+
+	case v.l != nil:
+		l := make([]any, len(v.l))
+		for i, val := range v.l {
+			l[i] = val.unwrap(keys)
+		}
+		return l
+	}
+
+	return v.v
+}
+
+func wrap(x any, keys map[uintptr][]string) any {
+	switch x := x.(type) {
+	case map[string]any:
+		kvs, ok := orderKvs(x, keys)
+		if !ok {
+			m := make(map[string]any, len(x))
+			for k, v := range x {
+				m[k] = wrap(v, keys)
+			}
+			return m
+		}
+		pairs := make([]orderedmap.Pair[string, any], len(kvs))
+		for i, kv := range kvs {
+			pairs[i] = orderedmap.Pair[string, any]{
+				Key:   kv.key,
+				Value: wrap(kv.val, keys),
+			}
+		}
+		return orderedmap.New[string, any](
+			orderedmap.WithInitialData(pairs...),
+		)
+
+	case []any:
+		l := make([]any, len(x))
+		for i, v := range x {
+			l[i] = wrap(v, keys)
+		}
+		return l
+
+	default:
+		return x
+	}
+}

--- a/cli/marshaler.go
+++ b/cli/marshaler.go
@@ -28,15 +28,23 @@ func (m *rawMarshaler) marshal(v any, w io.Writer) error {
 	return m.m.marshal(v, w)
 }
 
-func yamlFormatter(indent *int) *yamlMarshaler {
-	return &yamlMarshaler{indent}
+func yamlFormatter(indent *int, opts ...cliOption) *yamlMarshaler {
+	var c cliConfig
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return &yamlMarshaler{indent, c.keys}
 }
 
 type yamlMarshaler struct {
 	indent *int
+	keys   map[uintptr][]string
 }
 
 func (m *yamlMarshaler) marshal(v any, w io.Writer) error {
+	if len(m.keys) != 0 {
+		v = wrap(v, m.keys)
+	}
 	enc := yaml.NewEncoder(w)
 	if i := m.indent; i != nil {
 		enc.SetIndent(*i)

--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -8217,3 +8217,163 @@
   error: |
     unknown flag `--qqq'
   exit_code: 2
+
+- name: key order, json to json
+  args:
+    - '-c'
+    - '-k'
+    - '.'
+  input: '{"d":4, "c":{"y": 5, "z": 10, "x": 20}, "b":[{"open": 1, "close": 0}, {"close": 2, "open": 4}], "a":1}'
+  expected: |
+    {"d":4,"c":{"y":5,"z":10,"x":20},"b":[{"open":1,"close":0},{"close":2,"open":4}],"a":1}
+
+- name: key order, json to json (control)
+  args:
+    - '-c'
+    - '.'
+  input: '{"d":4, "c":{"y": 5, "z": 10, "x": 20}, "b":[{"open": 1, "close": 0}, {"close": 2, "open": 4}], "a":1}'
+  expected: |
+    {"a":1,"b":[{"close":0,"open":1},{"close":2,"open":4}],"c":{"x":20,"y":5,"z":10},"d":4}
+
+- name: key order, yaml to json
+  args:
+    - '-c'
+    - '-k'
+    - '--yaml-input'
+    - '.'
+  input: |
+    d: 4
+    c:
+      y: 5
+      z: 10
+      x: 20
+    b:
+      - open: 1
+        close: 0
+      - close: 2
+        open: 4
+    a: 1
+  expected: |
+    {"d":4,"c":{"y":5,"z":10,"x":20},"b":[{"open":1,"close":0},{"close":2,"open":4}],"a":1}
+
+- name: key order, yaml to json (control)
+  args:
+    - '-c'
+    - '--yaml-input'
+    - '.'
+  input: |
+    d: 4
+    c:
+      y: 5
+      z: 10
+      x: 20
+    b:
+      - open: 1
+        close: 0
+      - close: 2
+        open: 4
+    a: 1
+  expected: |
+    {"a":1,"b":[{"close":0,"open":1},{"close":2,"open":4}],"c":{"x":20,"y":5,"z":10},"d":4}
+
+- name: key order, json to yaml
+  args:
+    - '-c'
+    - '-k'
+    - '--yaml-output'
+    - '.'
+  input: '{"d":4, "c":{"y": 5, "z": 10, "x": 20}, "b":[{"open": 1, "close": 0}, {"close": 2, "open": 4}], "a":1}'
+  expected: |
+    d: 4
+    c:
+      "y": 5
+      z: 10
+      x: 20
+    b:
+      - open: 1
+        close: 0
+      - close: 2
+        open: 4
+    a: 1
+
+- name: key order, json to yaml (control)
+  args:
+    - '-c'
+    - '--yaml-output'
+    - '.'
+  input: '{"d":4, "c":{"y": 5, "z": 10, "x": 20}, "b":[{"open": 1, "close": 0}, {"close": 2, "open": 4}], "a":1}'
+  expected: |
+    a: 1
+    b:
+      - close: 0
+        open: 1
+      - close: 2
+        open: 4
+    c:
+      x: 20
+      "y": 5
+      z: 10
+    d: 4
+
+- name: key order, yaml to yaml
+  args:
+    - '-c'
+    - '-k'
+    - '--yaml-input'
+    - '--yaml-output'
+    - '.'
+  input: |
+    d: 4
+    c:
+      y: 5
+      z: 10
+      x: 20
+    b:
+      - open: 1
+        close: 0
+      - close: 2
+        open: 4
+    a: 1
+  expected: |
+    d: 4
+    c:
+      "y": 5
+      z: 10
+      x: 20
+    b:
+      - open: 1
+        close: 0
+      - close: 2
+        open: 4
+    a: 1
+
+- name: key order, yaml to yaml (control)
+  args:
+    - '-c'
+    - '--yaml-input'
+    - '--yaml-output'
+    - '.'
+  input: |
+    d: 4
+    c:
+      y: 5
+      z: 10
+      x: 20
+    b:
+      - open: 1
+        close: 0
+      - close: 2
+        open: 4
+    a: 1
+  expected: |
+    a: 1
+    b:
+      - close: 0
+        open: 1
+      - close: 2
+        open: 4
+    c:
+      x: 20
+      "y": 5
+      z: 10
+    d: 4

--- a/cli/yaml.go
+++ b/cli/yaml.go
@@ -2,29 +2,40 @@ package cli
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 )
 
 // Workaround for https://github.com/go-yaml/yaml/issues/139
-func normalizeYAML(v any) any {
+func normalizeYAML(v any, keys map[uintptr][]string) any {
 	switch v := v.(type) {
 	case map[any]any:
 		w := make(map[string]any, len(v))
 		for k, v := range v {
-			w[fmt.Sprint(k)] = normalizeYAML(v)
+			w[fmt.Sprint(k)] = normalizeYAML(v, keys)
+		}
+		ptr := uintptr(reflect.ValueOf(v).UnsafePointer())
+		if keyList, has := keys[ptr]; has {
+			ptr2 := uintptr(reflect.ValueOf(w).UnsafePointer())
+			keys[ptr2] = keyList
 		}
 		return w
 
 	case map[string]any:
 		w := make(map[string]any, len(v))
 		for k, v := range v {
-			w[k] = normalizeYAML(v)
+			w[k] = normalizeYAML(v, keys)
+		}
+		ptr := uintptr(reflect.ValueOf(v).UnsafePointer())
+		if keyList, has := keys[ptr]; has {
+			ptr2 := uintptr(reflect.ValueOf(w).UnsafePointer())
+			keys[ptr2] = keyList
 		}
 		return w
 
 	case []any:
 		for i, w := range v {
-			v[i] = normalizeYAML(w)
+			v[i] = normalizeYAML(w, keys)
 		}
 		return v
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,10 @@ require (
 )
 
 require (
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,14 @@
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/itchyny/timefmt-go v0.1.5 h1:G0INE2la8S6ru/ZI5JecgyzbbJNs5lG1RcBqa7Jm6GE=
 github.com/itchyny/timefmt-go v0.1.5/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
@@ -9,6 +16,8 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
I read feedback on https://github.com/itchyny/gojq/pull/189 and https://github.com/itchyny/gojq/issues/84 and implemented it in a way that does not change `gojq` (the library). Also it is completely optional and it only affects encoding and decoding. Everything in between is the same. Still it covers majority of my `jq` uses: pretty printing, extraction by path. Maps in JSON are often Go structs and preserving the order improves readability a lot.

It builds an external map from object pointer to the list of keys as seen in the input. If an object does not change during the whole operation of gojq, cli can find the original order of keys during encoding by looking into the map and checking if the set of keys is the same. This works for both JSON and YAML.

[go-ordered-map](https://pkg.go.dev/github.com/wk8/go-ordered-map/v2) is used as an intermediate object created during decoding and encoding (in case of YAML). After parsing is done, the list of keys is extracted from orderedmap and the map is turned into a regular `map[string]any`. A pointer to that map is added to a global table `map[uintptr][]string` which stores the order of keys. When encoding, this data is used to put keys in the right order.

Example:

```
$ echo '{"tx": {"open": 1, "close": 2}, "accept": true}' | gojq . 
{
  "accept": true,
  "tx": {
    "close": 2,
    "open": 1
  }
}

$ echo '{"tx": {"open": 1, "close": 2}, "accept": true}' | gojq -k . 
{
  "tx": {
    "open": 1,
    "close": 2
  },
  "accept": true
}
```