### PR TITLE
avoid issues when handling errors

### DIFF
--- a/cli/error.go
+++ b/cli/error.go
@@ -100,10 +100,11 @@ type jsonParseError struct {
 
 func (err *jsonParseError) Error() string {
 	var offset int
-	if err.err == io.ErrUnexpectedEOF {
+	var syntaxErr *json.SyntaxError
+	if errors.Is(err.err, io.ErrUnexpectedEOF) {
 		offset = len(err.contents) + 1
-	} else if e, ok := err.err.(*json.SyntaxError); ok {
-		offset = int(e.Offset)
+	} else if errors.As(err.err, &syntaxErr) {
+		offset = int(syntaxErr.Offset)
 	}
 	linestr, line, column := getLineByOffset(err.contents, offset)
 	if line += err.line; line > 1 {

--- a/cli/stream.go
+++ b/cli/stream.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 )
 
@@ -47,7 +48,7 @@ func (s *jsonStream) next() (any, error) {
 	for {
 		token, err := s.dec.Token()
 		if err != nil {
-			if err == io.EOF && s.states[len(s.states)-1] != jsonStateTopValue {
+			if errors.Is(err, io.EOF) && s.states[len(s.states)-1] != jsonStateTopValue {
 				err = io.ErrUnexpectedEOF
 			}
 			return nil, err

--- a/func.go
+++ b/func.go
@@ -844,7 +844,7 @@ func funcFromJSON(v any) any {
 	if err := dec.Decode(&w); err != nil {
 		return &func0WrapError{"fromjson", v, err}
 	}
-	if _, err := dec.Token(); err != io.EOF {
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
 		return &func0TypeError{"fromjson", v}
 	}
 	return normalizeNumbers(w)
@@ -2065,7 +2065,7 @@ func compileRegexp(re, flags string) (*regexp.Regexp, error) {
 	}
 	r, err := regexp.Compile(re)
 	if err != nil {
-		return nil, fmt.Errorf("invalid regular expression %q: %s", re, err)
+		return nil, fmt.Errorf("invalid regular expression %q: %w", re, err)
 	}
 	return r, nil
 }

--- a/module_loader.go
+++ b/module_loader.go
@@ -2,6 +2,7 @@ package gojq
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -98,7 +99,7 @@ func (l *moduleLoader) LoadJSONWithMeta(name string, meta map[string]any) (any, 
 	for {
 		var val any
 		if err := dec.Decode(&val); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if _, err := f.Seek(0, io.SeekStart); err != nil {


### PR DESCRIPTION
- external errors should be checked with errors.Is
- external errors should be compared with errors.As
- errors should be wrapped with %w in fmt.Errorf
