### PR TITLE
Add WithoutNormalize Compiler Option

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -340,6 +340,36 @@ func TestCodeRun_Race(t *testing.T) {
 	wg.Wait()
 }
 
+func TestCode_RunWithoutNormalize(t *testing.T) {
+	query, err := gojq.Parse(".foo")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	code, err := gojq.Compile(query)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	input := map[string]any{"foo": int32(1)}
+	_ = code.RunWithContext(context.Background(), input)
+	switch v := input["foo"].(type) {
+	case int: // ok
+	default:
+		t.Fatalf("expected int, got %T", v)
+	}
+
+	code, err = gojq.Compile(query, gojq.WithoutNormalize())
+	if err != nil {
+		log.Fatalln(err)
+	}
+	input = map[string]any{"foo": int32(1)} //need to recreate it as it was modified
+	_ = code.RunWithContext(context.Background(), input)
+	switch v := input["foo"].(type) {
+	case int32: // ok
+	default:
+		t.Fatalf("expected int32, got %T", v)
+	}
+}
+
 func BenchmarkCompile(b *testing.B) {
 	cnt, err := os.ReadFile("builtin.jq")
 	if err != nil {

--- a/func.go
+++ b/func.go
@@ -848,7 +848,7 @@ func funcFromJSON(v any) any {
 	if _, err := dec.Token(); err != io.EOF {
 		return &func0TypeError{"fromjson", v}
 	}
-	return normalizeNumbers(w)
+	return Normalize(w)
 }
 
 func funcFormat(v, x any) any {

--- a/normalize.go
+++ b/normalize.go
@@ -25,7 +25,16 @@ func normalizeNumber(v json.Number) any {
 	return math.Inf(1)
 }
 
-func normalizeNumbers(v any) any {
+// Normalize any given data.
+//
+// This function will in particular change any given map[any]any
+// so that all the integer values will be of type int and all the
+// floating point values will be of type float64. This method will
+// modify the given data in place.
+//
+// Typically running a gojq query will normalize the data automatically
+// unless the [WithoutNormalize] option has been specified.
+func Normalize(v any) any {
 	switch v := v.(type) {
 	case json.Number:
 		return normalizeNumber(v)
@@ -70,12 +79,12 @@ func normalizeNumbers(v any) any {
 		return float64(v)
 	case []any:
 		for i, x := range v {
-			v[i] = normalizeNumbers(x)
+			v[i] = Normalize(x)
 		}
 		return v
 	case map[string]any:
 		for k, x := range v {
-			v[k] = normalizeNumbers(x)
+			v[k] = Normalize(x)
 		}
 		return v
 	default:

--- a/option.go
+++ b/option.go
@@ -94,3 +94,11 @@ func WithInputIter(inputIter Iter) CompilerOption {
 		c.inputIter = inputIter
 	}
 }
+
+// WithoutNormalize ensures any given data won't be modified when executing code.
+// Note that the input data is expected to be normalized using the [Normalize] function.
+func WithoutNormalize() CompilerOption {
+	return func(c *compiler) {
+		c.skipNormalize = true
+	}
+}


### PR DESCRIPTION
This PR adds a `WithoutNormalize` compile option to the gojq compiler. When the option has been specified, data given to gojq won't be normalized, and therefore modified.

I ran into this issue when running many queries concurrent against a single set of data. It's not useful to normalize the data over and over again and also the only other to options are to either (a) hold a lock while running gojq or (b) creating copies of the data. I understand it makes sense to have this as a default but adding this option gives greater control over how, when and if the given data should be modified. 