### PR TITLE
change `NewIter()` into a generic function

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -352,7 +352,7 @@ func BenchmarkCompile(b *testing.B) {
 	for b.Loop() {
 		_, err := gojq.Compile(
 			query,
-			gojq.WithInputIter(gojq.NewIter()),
+			gojq.WithInputIter(gojq.NewIter[any]()),
 		)
 		if err != nil {
 			b.Fatal(err)

--- a/iter.go
+++ b/iter.go
@@ -6,14 +6,14 @@ type Iter interface {
 }
 
 // NewIter creates a new [Iter] from values.
-func NewIter(values ...any) Iter {
+func NewIter[T any](values ...T) Iter {
 	switch len(values) {
 	case 0:
 		return emptyIter{}
 	case 1:
 		return &unitIter{value: values[0]}
 	default:
-		iter := sliceIter(values)
+		iter := sliceIter[T](values)
 		return &iter
 	}
 }
@@ -37,9 +37,9 @@ func (iter *unitIter) Next() (any, bool) {
 	return iter.value, true
 }
 
-type sliceIter []any
+type sliceIter[T any] []T
 
-func (iter *sliceIter) Next() (any, bool) {
+func (iter *sliceIter[T]) Next() (any, bool) {
 	if len(*iter) == 0 {
 		return nil, false
 	}

--- a/option_test.go
+++ b/option_test.go
@@ -629,7 +629,7 @@ func TestWithIterFunction(t *testing.T) {
 			return gojq.NewIter(fmt.Errorf("g cannot be applied to: %v", xs))
 		}),
 		gojq.WithIterFunction("h", 0, 0, func(any, []any) gojq.Iter {
-			return gojq.NewIter()
+			return gojq.NewIter[any]()
 		}),
 	)
 	if err != nil {
@@ -659,7 +659,7 @@ func TestWithIterFunctionError(t *testing.T) {
 	}
 	code, err := gojq.Compile(query,
 		gojq.WithIterFunction("f", 0, 0, func(any, []any) gojq.Iter {
-			return gojq.NewIter(1, errors.New("error"), 3)
+			return gojq.NewIter[any](1, errors.New("error"), 3)
 		}),
 	)
 	if err != nil {
@@ -750,7 +750,7 @@ func TestWithIterFunctionPathEmpty(t *testing.T) {
 	}
 	code, err := gojq.Compile(query,
 		gojq.WithIterFunction("f", 0, 0, func(any, []any) gojq.Iter {
-			return gojq.NewIter()
+			return gojq.NewIter[any]()
 		}),
 	)
 	if err != nil {
@@ -838,7 +838,7 @@ func TestWithIterFunctionDefineError(t *testing.T) {
 			return 0
 		}),
 		gojq.WithIterFunction("f", 0, 0, func(any, []any) gojq.Iter {
-			return gojq.NewIter()
+			return gojq.NewIter[any]()
 		}),
 	))
 }


### PR DESCRIPTION
`func IterFrom[T any](values ...T) Iter` (name open for discussion) has a signature that can accept slices of other types (such as `[]string`).
```go
gojq.IterFrom(strings.Split("a b c d e", " ")...) // valid
gojq.NewIter(strings.Split("a b c d e", " ")...) // cannot use variable of type []string as []any value
```

Fixes #284