### PR TITLE
display width performance for getLineByOffset

### DIFF
--- a/cli/error.go
+++ b/cli/error.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/clipperhouse/displaywidth"
 	"github.com/itchyny/go-yaml"
-	"github.com/mattn/go-runewidth"
 
 	"github.com/itchyny/gojq"
 )
@@ -169,7 +169,7 @@ func getLineByOffset(str string, offset int) (linestr string, line, column int) 
 	} else {
 		offset = len(linestr)
 	}
-	column = runewidth.StringWidth(linestr[:offset])
+	column = displaywidth.String(linestr[:offset])
 	return
 }
 

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -170,3 +170,72 @@ func TestGetLineByOffset(t *testing.T) {
 		})
 	}
 }
+
+func benchJQQuery(size int) string {
+	lines := []string{
+		"def map_values(f): [.[] | f];",
+		".[] | select(.age > 21) | {name, age}",
+		"if .status == \"active\" then .name else empty end",
+		"reduce .[] as $x (0; . + $x)",
+		"[.items[] | {key: .id, value: .count}] | from_entries",
+		"def walk(f): . as $in | if type == \"object\" then",
+		"  reduce keys_unsorted[] as $k ({}; . + {($k): ($in[$k] | walk(f))})",
+		"elif type == \"array\" then map(walk(f)) else f end;",
+	}
+	var sb strings.Builder
+	for sb.Len() < size {
+		sb.WriteString(lines[sb.Len()%len(lines)])
+		sb.WriteByte('\n')
+	}
+	return sb.String()[:size]
+}
+
+func benchJSONLines(size int) string {
+	line := `{"id":12345,"name":"Alice Johnson","active":true,"score":98.6,"tags":["admin","user"]}` + "\n"
+	var sb strings.Builder
+	for sb.Len() < size {
+		sb.WriteString(line)
+	}
+	return sb.String()[:size]
+}
+
+func benchYAML(size int) string {
+	entry := "- id: 42\n  name: Alice Johnson\n  active: true\n  address:\n    street: 123 Main St\n    city: Springfield\n"
+	var sb strings.Builder
+	for sb.Len() < size {
+		sb.WriteString(entry)
+	}
+	return sb.String()[:size]
+}
+
+func BenchmarkGetLineByOffset(b *testing.B) {
+	// queryParseError: jq source — inline arg or -f file, typically short.
+	// jsonParseError: ~16 KiB window (seekable) or full buffered stdin.
+	// yamlParseError: full file contents (no windowing).
+	query := benchJQQuery(2048)
+	jsonWindow := benchJSONLines(16 * 1024)
+	yamlFull := benchYAML(64 * 1024)
+	unicodeLine := "{\n  \"k\": \"" + strings.Repeat("０１２", 120) + "\",\n  \"x\": 1\n}"
+	cases := []struct {
+		name   string
+		str    string
+		offset int
+	}{
+		{"query_inline", ".foo | select(.x > 1)", 15},
+		{"query_2KiB_mid", query, len(query) / 2},
+		{"json_16KiB_mid", jsonWindow, len(jsonWindow) / 2},
+		{"json_16KiB_end", jsonWindow, len(jsonWindow)},
+		{"json_unicode", unicodeLine, strings.Index(unicodeLine, "０")},
+		{"yaml_64KiB_mid", yamlFull, len(yamlFull) / 2},
+		{"yaml_64KiB_end", yamlFull, len(yamlFull)},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.str)))
+			for b.Loop() {
+				getLineByOffset(tc.str, tc.offset)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,14 @@ module github.com/itchyny/gojq
 go 1.24.0
 
 require (
+	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/google/go-cmp v0.7.0
 	github.com/itchyny/go-yaml v0.0.0-20251001235044-fca9a0999f15
 	github.com/itchyny/timefmt-go v0.1.8
 	github.com/mattn/go-isatty v0.0.20
-	github.com/mattn/go-runewidth v0.0.19
 )
 
 require (
-	github.com/clipperhouse/stringish v0.1.1 // indirect
-	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
-github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
-github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
-github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
+github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
+github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
+github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/itchyny/go-yaml v0.0.0-20251001235044-fca9a0999f15 h1:m4jKsIK0QS9ihQzOxUN2zJcPdrACwqIWCwvdzv9skMQ=
@@ -10,8 +10,6 @@ github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo79
 github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
-github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
Dropped in a different (my) library for terminal widths. Tests look good, benchmarks below:

```
goos: darwin
goarch: arm64
pkg: github.com/itchyny/gojq/cli
cpu: Apple M2
```

Before:

```
BenchmarkGetLineByOffset/query_inline-8            138.2 ns/op	       151.91 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/query_2KiB_mid-8          597.3 ns/op	      3428.55 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/json_16KiB_mid-8         1659 ns/op	      9876.64 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/json_16KiB_end-8         3283 ns/op	      4991.28 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/json_unicode-8            120.0 ns/op	      9188.66 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/yaml_64KiB_mid-8        28795 ns/op	      2275.97 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/yaml_64KiB_end-8        57370 ns/op	      1142.34 MB/s	     0 B/op	    0 allocs/op
```

After:

```
BenchmarkGetLineByOffset/query_inline-8             16.81 ns/op	      1249.52 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/query_2KiB_mid-8          360.9 ns/op	      5675.26 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/json_16KiB_mid-8         1553 ns/op	     10552.65 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/json_16KiB_end-8         3062 ns/op	      5350.25 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/json_unicode-8             59.08 ns/op	     18670.63 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/yaml_64KiB_mid-8        28716 ns/op	      2282.25 MB/s	     0 B/op	    0 allocs/op
BenchmarkGetLineByOffset/yaml_64KiB_end-8        57259 ns/op	      1144.56 MB/s	     0 B/op	    0 allocs/op
```

AI disclosure: I wrote the code (1 line!) and had Claude write the benchmarks, based on analyzing how `getLineByOffset` is called.