### PR TITLE
fix: handle int64 and int32 in encoder type switch

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -59,6 +59,10 @@ func (e *encoder) encode(v any) {
 		}
 	case int:
 		e.w.Write(strconv.AppendInt(e.buf[:0], int64(v), 10))
+	case int64:
+		e.w.Write(strconv.AppendInt(e.buf[:0], v, 10))
+	case int32:
+		e.w.Write(strconv.AppendInt(e.buf[:0], int64(v), 10))
 	case float64:
 		e.encodeFloat64(v)
 	case *big.Int:


### PR DESCRIPTION
## Problem

The encoder panics on `int64` and `int32` values with `invalid type: int64 (...)` because only `int` is handled in the type switch (`encoder.go:60`).

This is a problem when using gojq as a library with data from Kubernetes, where `sigs.k8s.io/json.UnmarshalCaseSensitivePreserveInts` deserializes JSON integer numbers as `int64` rather than `int`. On 64-bit systems `int` and `int64` have the same size but are different Go types, causing the encoder's default panic.

## Fix

Add `case int64:` and `case int32:` alongside the existing `case int:` in the encoder's type switch. Both convert to `int64` for `strconv.AppendInt`, matching the existing `int` behavior.

## Test

All existing tests pass.