### PR TITLE
Add MustParse func

### DIFF
--- a/query.go
+++ b/query.go
@@ -2,6 +2,7 @@ package gojq
 
 import (
 	"context"
+	"fmt"
 	"strings"
 )
 
@@ -17,6 +18,17 @@ func Parse(src string) (*Query, error) {
 		return nil, l.err
 	}
 	return l.result, nil
+}
+
+// MustParse is like [Parse] but panics if the query cannot be parsed.
+// It is intended for use in global variable declarations, where a parse
+// failure indicates a programming error rather than a runtime condition.
+func MustParse(src string) *Query {
+	q, err := Parse(src)
+	if err != nil {
+		panic(fmt.Sprintf("gojq: MustParse(%q): %s", src, err))
+	}
+	return q
 }
 
 // Query represents the abstract syntax tree of a jq query.

--- a/query_test.go
+++ b/query_test.go
@@ -365,6 +365,62 @@ func TestQueryString(t *testing.T) {
 	}
 }
 
+func TestMustParse(t *testing.T) {
+	tests := []struct {
+		src      string
+		expected string
+	}{
+		{".foo", ".foo"},
+		{".foo | .bar", ".foo | .bar"},
+		{".[0]", ".[0]"},
+		{"empty", "empty"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.src, func(t *testing.T) {
+			q := gojq.MustParse(test.src)
+			if q == nil {
+				t.Fatal("expected non-nil query")
+			}
+			if got := q.String(); got != test.expected {
+				t.Errorf("expected: %q, got: %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestMustParse_Panic(t *testing.T) {
+	tests := []struct {
+		src           string
+		panicContains string
+	}{
+		{"^", `gojq: MustParse("^"):`},
+		{".foo |", `gojq: MustParse(".foo |"):`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.src, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatal("expected panic but got none")
+				}
+
+				msg, ok := r.(string)
+				if !ok {
+					t.Fatalf("expected panic string, got %T: %v", r, r)
+				}
+
+				if !strings.Contains(msg, test.panicContains) {
+					t.Errorf("expected panic message to contain %q, got: %q", test.panicContains, msg)
+				}
+			}()
+
+			gojq.MustParse(test.src)
+		})
+	}
+}
+
 func BenchmarkRun(b *testing.B) {
 	query, err := gojq.Parse("range(1000)")
 	if err != nil {


### PR DESCRIPTION
This PR introduces a `MustParse` function, inspired by the `regexp.MustCompile` func from stdlib.
It simplifies the definition of global variables when using `gojq` as a lib.

