### PR TITLE
fix panic on continuing iteration after an invalid path error

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -271,6 +271,7 @@ loop:
 			case []any:
 				if !env.paths.empty() && env.expdepth == 0 && !env.pathIntact(v) {
 					err = &invalidPathIterError{v}
+					env.push(emptyIter{})
 					break loop
 				}
 				if len(v) == 0 {
@@ -283,6 +284,7 @@ loop:
 			case map[string]any:
 				if !env.paths.empty() && env.expdepth == 0 && !env.pathIntact(v) {
 					err = &invalidPathIterError{v}
+					env.push(emptyIter{})
 					break loop
 				}
 				if len(v) == 0 {

--- a/query_test.go
+++ b/query_test.go
@@ -225,6 +225,42 @@ func TestQueryRun_InvalidPathError(t *testing.T) {
 	}
 }
 
+func TestQueryRun_InvalidPathIterError(t *testing.T) {
+	for _, tc := range []struct {
+		query    string
+		expected string
+	}{
+		{"path([][])", "invalid path on iterating against: array ([])"},
+		{"path([1][])", "invalid path on iterating against: array ([1])"},
+		{"path({}[])", "invalid path on iterating against: object ({})"},
+		{`path({"a":1}[])`, `invalid path on iterating against: object ({"a":1})`},
+	} {
+		query, err := gojq.Parse(tc.query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		iter := query.Run(0)
+		n := 0
+		for {
+			v, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if err, ok := v.(error); ok {
+				if err.Error() != tc.expected {
+					t.Errorf("expected: %v, got: %v", tc.expected, err)
+				}
+			} else {
+				t.Errorf("should emit an error but got: %v", v)
+			}
+			n++
+		}
+		if expected := 1; n != expected {
+			t.Errorf("expected: %v, got: %v", expected, n)
+		}
+	}
+}
+
 func TestQueryRun_IteratorError(t *testing.T) {
 	query, err := gojq.Parse(".[]")
 	if err != nil {


### PR DESCRIPTION
Driving the iterator past an invalid path error panics:

```go
q, _ := gojq.Parse("path([][])")
code, _ := gojq.Compile(q)
iter := code.Run(nil)
for {
    _, ok := iter.Next()
    if !ok {
        break
    }
}
```

```
panic: runtime error: index out of range [-1]

github.com/itchyny/gojq.(*stack).pop(...)
	stack.go:29
github.com/itchyny/gojq.(*env).pop(...)
	execute.go:365
github.com/itchyny/gojq.(*env).Next(0xc004825088)
	execute.go:268
```

The first `Next` correctly returns `invalid path on iterating against: array ([])` with `ok == true`; the second one panics. The `gojq` command stops at the first error so it never hits this, but the README describes continuing past errors as a supported choice for library users:

> The `jq` and `gojq` commands stop the iteration on the first error, but the library user can choose to stop the iteration on errors, or to continue until it terminates.

Also reproducible with `path([1][])`, `path({}[])`, `path([] | .[])`, `path([][] | .a)` and `path([][][])`, on any input.

### Cause

`opiter` pops the value it is about to iterate before inspecting it, so every error exit from that instruction has to leave the stack balanced. When `Next` returns an error and there are no forks left to backtrack into, the deferred `env.pc, env.backtrack = pc, true` leaves `pc` on the same `opiter`, and `err` is a local that starts out nil on the following call — so `if err != nil { break loop }` does not fire and the instruction pops a second time from a stack that was never restored.

The `iteratorError` branch already handles this by pushing an `emptyIter{}` before breaking, which makes the resumed instruction take the `case Iter` path, get `ok == false`, and end the iteration cleanly. The two `invalidPathIterError` branches were missing that push.

### Fix

Push `emptyIter{}` on those two branches as well. Each affected query now emits its error exactly once and then terminates, matching `path(1)` and the other path errors. When there *are* forks left, `popfork` restores the stack index and discards the pushed value, so nothing changes on that path.

### Tests

`TestQueryRun_InvalidPathIterError` added next to the existing `TestQueryRun_InvalidPathError`, covering the array and object branches with both empty and non-empty values, and asserting exactly one emitted error before termination. It panics on `main` and passes with this change.

### Verification

Matches an unmodified `main` on the same machine, everything green:

- `go test -race ./...`
- `GOARCH=386 go test ./...`
- `go vet ./...`
- `staticcheck -checks all -tags gojq_debug ./...` (no findings)
- `go generate` produces no diff
- `gofmt -l .` reports only `builtin.go`, which is generated and identical on `main`

### How I found it

`FuzzQueryRun` did not reach this because it has no seed corpus, skips any query longer than 16 bytes, and only ever runs against `nil` input. I ran a local variant seeded with the ~700 queries from `cli/test.yaml`, paired with inputs from the same file, and continuing the iteration past errors. It reached this in a few minutes and found nothing else in ~20M executions. If you'd like, I can send a follow-up that seeds the in-tree fuzz target the same way.
