### PR TITLE
add MaxAlloc to bound the memory a single query run may allocate

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ func main() {
       The `halt` function in jq not only stops the iteration, but also terminates the command execution, even if there are still input values.
       So, gojq leaves it up to the library user how to handle the halting error.
   - Note that the result iterator may emit infinite number of values; `repeat(0)` and `range(infinite)`. It may stuck with no output value; `def f: f; f`. Use `RunWithContext` when you want to limit the execution time.
+  - Note that a query may allocate a large amount of memory; `[range(1000000000)]`. Set [`gojq.MaxAlloc`](https://pkg.go.dev/github.com/itchyny/gojq#MaxAlloc) when you want to bound the total allocation of a single run; the run stops with an allocation error once the budget is exceeded. The default value `0` means unlimited.
 
 [`gojq.Compile`](https://pkg.go.dev/github.com/itchyny/gojq#Compile) allows to configure the following compiler options.
 

--- a/code.go
+++ b/code.go
@@ -5,6 +5,13 @@ type code struct {
 	op opcode
 }
 
+type scopeCode struct {
+	id            int
+	variableCount int
+	argumentCount int
+	builtin       bool
+}
+
 type opcode int
 
 const (
@@ -28,6 +35,7 @@ const (
 	opindex
 	opindexarray
 	opcall
+	opcalltail
 	opcallrec
 	oppushpc
 	opcallpc
@@ -84,6 +92,8 @@ func (op opcode) String() string {
 		return "call"
 	case opcallrec:
 		return "callrec"
+	case opcalltail:
+		return "calltail"
 	case oppushpc:
 		return "pushpc"
 	case opcallpc:

--- a/compare.go
+++ b/compare.go
@@ -11,6 +11,18 @@ import (
 // The result will be 0 if l == r, -1 if l < r, and +1 if l > r.
 // This comparison is used by built-in operators and functions.
 func Compare(l, r any) int {
+	return compareDepth(l, r, 0)
+}
+
+// compareDepth is Compare with a recursion-depth bound. Compare recurses on
+// nested arrays and objects; a deeply nested value ( >= 16 bytes per level )
+// would overflow the goroutine stack ( a fatal crash ) inside sort, unique, min,
+// the comparison operators, etc. Past the depth a value already exceeds the
+// limit, so panic; the interpreter's Next recovers it.
+func compareDepth(l, r any, depth int) int {
+	if MaxAlloc > 0 && (int64(depth)*16 > MaxAlloc || depth > maxRecursionDepth) {
+		panic(&allocLimitError{})
+	}
 	return binopTypeSwitch(l, r,
 		cmp.Compare,
 		func(l, r float64) int {
@@ -27,7 +39,7 @@ func Compare(l, r any) int {
 		cmp.Compare,
 		func(l, r []any) int {
 			for i := range min(len(l), len(r)) {
-				if cmp := Compare(l[i], r[i]); cmp != 0 {
+				if cmp := compareDepth(l[i], r[i], depth+1); cmp != 0 {
 					return cmp
 				}
 			}
@@ -35,11 +47,11 @@ func Compare(l, r any) int {
 		},
 		func(l, r map[string]any) int {
 			lk, rk := funcKeys(l), funcKeys(r)
-			if cmp := Compare(lk, rk); cmp != 0 {
+			if cmp := compareDepth(lk, rk, depth+1); cmp != 0 {
 				return cmp
 			}
 			for _, k := range lk.([]any) {
-				if cmp := Compare(l[k.(string)], r[k.(string)]); cmp != 0 {
+				if cmp := compareDepth(l[k.(string)], r[k.(string)], depth+1); cmp != 0 {
 					return cmp
 				}
 			}

--- a/compiler.go
+++ b/compiler.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 )
 
 type compiler struct {
@@ -22,7 +21,7 @@ type compiler struct {
 	builtinScope  *scopeinfo
 	scopes        []*scopeinfo
 	scopecnt      int
-	regexpCache   sync.Map
+	regexpCache   reCache
 }
 
 // Code is a compiled jq query.

--- a/compiler.go
+++ b/compiler.go
@@ -19,6 +19,7 @@ type compiler struct {
 	codes         []*code
 	codeinfos     []codeinfo
 	builtinScope  *scopeinfo
+	builtinDepth  int
 	scopes        []*scopeinfo
 	scopecnt      int
 	regexpCache   reCache
@@ -80,7 +81,7 @@ func Compile(q *Query, options ...CompilerOption) (*Code, error) {
 	scope := c.newScope()
 	c.scopes = []*scopeinfo{scope}
 	setscope := c.lazy(func() *code {
-		return &code{op: opscope, v: [3]int{scope.id, scope.variablecnt, 0}}
+		return &code{op: opscope, v: scopeCode{id: scope.id, variableCount: scope.variablecnt}}
 	})
 	for _, name := range c.variables {
 		if !newLexer(name).validVarName() {
@@ -309,6 +310,11 @@ func (c *compiler) newScopeDepth() func() {
 }
 
 func (c *compiler) compileFuncDef(e *FuncDef, builtin bool) error {
+	if builtin {
+		c.builtinDepth++
+		defer func() { c.builtinDepth-- }()
+	}
+	isBuiltin := c.builtinDepth > 0
 	var scope *scopeinfo
 	if builtin {
 		scope = c.builtinScope
@@ -331,7 +337,10 @@ func (c *compiler) compileFuncDef(e *FuncDef, builtin bool) error {
 		c.scopes = append(c.scopes, scope)
 	}
 	defer c.lazy(func() *code {
-		return &code{op: opscope, v: [3]int{scope.id, scope.variablecnt, len(e.Args)}}
+		return &code{op: opscope, v: scopeCode{
+			id: scope.id, variableCount: scope.variablecnt,
+			argumentCount: len(e.Args), builtin: isBuiltin,
+		}}
 	})()
 	if len(e.Args) > 0 {
 		type varIndex struct {
@@ -1041,7 +1050,7 @@ func (c *compiler) compileAssign() {
 	// Cannot reuse v, p due to backtracking in x.
 	w, q := [2]int{scope.id, 4}, [2]int{scope.id, 5}
 	c.appends(
-		&code{op: opscope, v: [3]int{scope.id, 6, 2}},
+		&code{op: opscope, v: scopeCode{id: scope.id, variableCount: 6, argumentCount: 2, builtin: true}},
 		&code{op: opstore, v: v}, //                def _assign(p; $x):
 		&code{op: opstore, v: p},
 		&code{op: opstore, v: x},
@@ -1086,7 +1095,7 @@ func (c *compiler) compileModify() {
 	f, d := [2]int{scope.id, 2}, [2]int{scope.id, 3}
 	a, l := [2]int{scope.id, 4}, [2]int{scope.id, 5}
 	c.appends(
-		&code{op: opscope, v: [3]int{scope.id, 6, 2}},
+		&code{op: opscope, v: scopeCode{id: scope.id, variableCount: 6, argumentCount: 2, builtin: true}},
 		&code{op: opstore, v: v}, //                def _modify(p; f):
 		&code{op: opstore, v: p},
 		&code{op: opstore, v: f},
@@ -1141,7 +1150,7 @@ func (c *compiler) compileLast() {
 	scope := c.newScope()
 	v, g, x := [2]int{scope.id, 0}, [2]int{scope.id, 1}, [2]int{scope.id, 2}
 	c.appends(
-		&code{op: opscope, v: [3]int{scope.id, 3, 1}},
+		&code{op: opscope, v: scopeCode{id: scope.id, variableCount: 3, argumentCount: 1, builtin: true}},
 		&code{op: opstore, v: v},
 		&code{op: opstore, v: g},
 		&code{op: oppush, v: true}, //              $x = true
@@ -1646,21 +1655,21 @@ func (c *compiler) lazy(f func() *code) func() {
 
 func (c *compiler) optimizeTailRec() {
 	var pcs []int
-	scopes := map[int]bool{}
+	scopes := map[int]scopeCode{}
 L:
 	for i, code := range c.codes {
 		switch code.op {
 		case opscope:
 			pcs = append(pcs, i)
-			if v := code.v.([3]int); v[2] == 0 {
-				scopes[i] = v[1] == 0
+			if v := code.v.(scopeCode); v.argumentCount == 0 {
+				scopes[i] = v
 			}
 		case opcall:
-			var canjump bool
+			var tailScope scopeCode
 			if j, ok := code.v.(int); !ok ||
 				len(pcs) == 0 || pcs[len(pcs)-1] != j {
 				break
-			} else if canjump, ok = scopes[j]; !ok {
+			} else if tailScope, ok = scopes[j]; !ok {
 				break
 			}
 			for j := i + 1; j < len(c.codes); {
@@ -1668,7 +1677,9 @@ L:
 				case opjump:
 					j = c.codes[j].v.(int)
 				case opret:
-					if canjump {
+					if !tailScope.builtin {
+						code.op = opcalltail
+					} else if tailScope.variableCount == 0 {
 						code.op = opjump
 						code.v = pcs[len(pcs)-1] + 1
 					} else {

--- a/debug.go
+++ b/debug.go
@@ -79,7 +79,7 @@ func (env *env) debugCodes() {
 	for i, c := range env.codes {
 		pc := i
 		switch c.op {
-		case opcall, opcallrec:
+		case opcall, opcallrec, opcalltail:
 			if x, ok := c.v.(int); ok {
 				pc = x
 			}
@@ -92,7 +92,7 @@ func (env *env) debugCodes() {
 		var s string
 		if name := env.lookupInfoName(pc); name != "" {
 			switch c.op {
-			case opcall, opcallrec, opjump:
+			case opcall, opcallrec, opcalltail, opjump:
 				if !strings.HasPrefix(name, "module ") {
 					s = "\t## call " + name
 					break
@@ -127,7 +127,7 @@ func (env *env) debugState(pc int, backtrack bool) {
 		sb.WriteString(debugValue(env.stack.data[xs[i]].value))
 	}
 	switch c.op {
-	case opcall, opcallrec:
+	case opcall, opcallrec, opcalltail:
 		if x, ok := c.v.(int); ok {
 			pc = x
 		}
@@ -139,7 +139,7 @@ func (env *env) debugState(pc int, backtrack bool) {
 	}
 	if name := env.lookupInfoName(pc); name != "" {
 		switch c.op {
-		case opcall, opcallrec, opjump:
+		case opcall, opcallrec, opcalltail, opjump:
 			if !strings.HasPrefix(name, "module ") {
 				sb.WriteString("\t\t\t## call " + name)
 				break
@@ -174,7 +174,7 @@ func (env *env) debugForks(pc int, op string) {
 
 func debugOperand(c *code) string {
 	switch c.op {
-	case opcall, opcallrec:
+	case opcall, opcallrec, opcalltail:
 		switch v := c.v.(type) {
 		case int:
 			return strconv.Itoa(v)
@@ -196,8 +196,8 @@ func debugValue(v any) string {
 		return fmt.Sprintf("[]gojq.pathValue(%v)", v)
 	case [2]int:
 		return fmt.Sprintf("[%d,%d]", v[0], v[1])
-	case [3]int:
-		return fmt.Sprintf("[%d,%d,%d]", v[0], v[1], v[2])
+	case scopeCode:
+		return fmt.Sprintf("[%d,%d,%d]", v.id, v.variableCount, v.argumentCount)
 	case [3]any:
 		return fmt.Sprintf("[%v,%v,%v]", v[0], v[1], v[2])
 	case allocator:

--- a/encoder.go
+++ b/encoder.go
@@ -23,7 +23,16 @@ import (
 // and does not escape '<', '>', '&', '\u2028', and '\u2029'. These behaviors
 // are based on the marshaler of jq command, and different from json.Marshal in
 // the Go standard library. Note that the result is not safe to embed in HTML.
-func Marshal(v any) ([]byte, error) {
+func Marshal(v any) (bs []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(*allocLimitError); ok {
+				bs, err = nil, &allocLimitError{}
+				return
+			}
+			panic(r)
+		}
+	}()
 	var b bytes.Buffer
 	(&encoder{w: &b}).encode(v)
 	return b.Bytes(), nil
@@ -35,6 +44,40 @@ func jsonMarshal(v any) string {
 	return sb.String()
 }
 
+// jsonMarshalTruncated is jsonMarshal but returns the bounded prefix built so far
+// instead of letting the encode guard's *allocLimitError panic escape. Error() and
+// String() methods cannot return an error, so a big value would otherwise crash
+// formatting. jsonMarshal itself must keep panicking, since marshalBounded relies
+// on that to report the limit as an error.
+func jsonMarshalTruncated(v any) (s string) {
+	var sb strings.Builder
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(*allocLimitError); !ok {
+				panic(r)
+			}
+			s = sb.String()
+		}
+	}()
+	(&encoder{w: &sb}).encode(v)
+	return sb.String()
+}
+
+// marshalBounded is jsonMarshal, but returns an allocLimitError instead of
+// building an encoding larger than MaxAlloc (see encode).
+func marshalBounded(v any) (s string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(*allocLimitError); ok {
+				err = &allocLimitError{}
+				return
+			}
+			panic(r)
+		}
+	}()
+	return jsonMarshal(v), nil
+}
+
 func jsonEncodeString(sb *strings.Builder, v string) {
 	(&encoder{w: sb}).encodeString(v)
 }
@@ -44,11 +87,20 @@ type encoder struct {
 		io.Writer
 		io.ByteWriter
 		io.StringWriter
+		Len() int
 	}
-	buf [64]byte
+	buf   [64]byte
+	depth int
 }
 
 func (e *encoder) encode(v any) {
+	// Shared references (e.g. `[., .]` repeated) make a value whose own
+	// footprint is tiny expand to an exponentially larger encoding. Bound the
+	// output so tojson / tostring / @json cannot build gigabytes before the
+	// value meter, which only sees the finished string, could charge it.
+	if MaxAlloc > 0 && int64(e.w.Len()) > MaxAlloc {
+		panic(&allocLimitError{})
+	}
 	switch v := v.(type) {
 	case nil:
 		e.w.WriteString("null")
@@ -63,6 +115,14 @@ func (e *encoder) encode(v any) {
 	case float64:
 		e.encodeFloat64(v)
 	case *big.Int:
+		// Converting a big integer to base 10 allocates large superlinear scratch
+		// inside math/big (a 4 MB integer peaks past 100 MB), none of it visible to
+		// the between-values guard above. Reject one whose decimal form could pass
+		// the limit; the widest realistic integer is tiny, so this only refuses
+		// absurd multi-hundred-thousand-digit values.
+		if MaxAlloc > 0 && int64(len(v.Bits()))*384 > MaxAlloc {
+			panic(&allocLimitError{})
+		}
 		e.w.Write(v.Append(e.buf[:0], 10))
 	case json.Number:
 		e.w.WriteString(v.String())
@@ -112,6 +172,9 @@ func (e *encoder) encodeString(s string) {
 			if start < i {
 				e.w.WriteString(s[start:i])
 			}
+			if MaxAlloc > 0 && int64(e.w.Len()) > MaxAlloc {
+				panic(&allocLimitError{})
+			}
 			switch b {
 			case '"':
 				e.w.WriteString(`\"`)
@@ -142,6 +205,9 @@ func (e *encoder) encodeString(s string) {
 			if start < i {
 				e.w.WriteString(s[start:i])
 			}
+			if MaxAlloc > 0 && int64(e.w.Len()) > MaxAlloc {
+				panic(&allocLimitError{})
+			}
 			e.w.WriteString(`\ufffd`)
 			i += size
 			start = i
@@ -156,6 +222,15 @@ func (e *encoder) encodeString(s string) {
 }
 
 func (e *encoder) encodeArray(vs []any) {
+	// Bound the recursion depth. encode is Go-recursive and is not covered by
+	// the interpreter's overStackLimit, and the buffer guard does not fire on a
+	// deep-narrow value ( each level adds one byte on the way down ), so a deeply
+	// nested value overflowed the goroutine stack ( a fatal, unrecoverable crash ).
+	// A value this deep is already larger than the limit ( >= 16 bytes per level ).
+	if e.depth++; MaxAlloc > 0 && (int64(e.depth)*16 > MaxAlloc || e.depth > maxRecursionDepth) {
+		panic(&allocLimitError{})
+	}
+	defer func() { e.depth-- }()
 	e.w.WriteByte('[')
 	for i, v := range vs {
 		if i > 0 {
@@ -167,10 +242,17 @@ func (e *encoder) encodeArray(vs []any) {
 }
 
 func (e *encoder) encodeObject(vs map[string]any) {
+	if e.depth++; MaxAlloc > 0 && (int64(e.depth)*16 > MaxAlloc || e.depth > maxRecursionDepth) {
+		panic(&allocLimitError{})
+	}
+	defer func() { e.depth-- }()
 	e.w.WriteByte('{')
 	type keyVal struct {
 		key string
 		val any
+	}
+	if MaxAlloc > 0 && int64(len(vs))*32 > MaxAlloc {
+		panic(&allocLimitError{})
 	}
 	kvs := make([]keyVal, len(vs))
 	var i int

--- a/env.go
+++ b/env.go
@@ -3,29 +3,32 @@ package gojq
 import "context"
 
 type env struct {
-	pc        int
-	stack     *stack
-	paths     *stack
-	scopes    *scopeStack
-	values    []any
-	codes     []*code
-	codeinfos []codeinfo
-	forks     []fork
-	backtrack bool
-	offset    int
-	expdepth  int
-	label     int
-	args      [32]any // len(env.args) > maxarity
-	ctx       context.Context
-	alloc     int64
+	pc            int
+	stack         *stack
+	paths         *stack
+	scopes        *scopeStack
+	values        []any
+	codes         []*code
+	codeinfos     []codeinfo
+	forks         []fork
+	backtrack     bool
+	offset        int
+	expdepth      int
+	label         int
+	args          [32]any // len(env.args) > maxarity
+	ctx           context.Context
+	alloc         int64
+	maxStackDepth int
+	tailDepth     int
 }
 
 func newEnv(ctx context.Context) *env {
 	return &env{
-		stack:  newStack(),
-		paths:  newStack(),
-		scopes: newScopeStack(),
-		ctx:    ctx,
+		stack:         newStack(),
+		paths:         newStack(),
+		scopes:        newScopeStack(),
+		ctx:           ctx,
+		maxStackDepth: configuredStackDepth(),
 	}
 }
 
@@ -35,6 +38,7 @@ type scope struct {
 	pc         int
 	saveindex  int
 	outerindex int
+	tailDepth  int
 }
 
 type fork struct {
@@ -47,4 +51,5 @@ type fork struct {
 	pathlimit  int
 	offset     int
 	expdepth   int
+	tailDepth  int
 }

--- a/env.go
+++ b/env.go
@@ -17,6 +17,7 @@ type env struct {
 	label     int
 	args      [32]any // len(env.args) > maxarity
 	ctx       context.Context
+	alloc     int64
 }
 
 func newEnv(ctx context.Context) *env {

--- a/error.go
+++ b/error.go
@@ -178,7 +178,7 @@ func (err *exitCodeError) Error() string {
 	if s, ok := err.value.(string); ok {
 		return "error: " + s
 	}
-	return "error: " + jsonMarshal(err.value)
+	return "error: " + jsonMarshalTruncated(err.value)
 }
 
 func (err *exitCodeError) Value() any {

--- a/execute.go
+++ b/execute.go
@@ -9,6 +9,9 @@ import (
 )
 
 func (env *env) execute(bc *Code, v any, vars ...any) Iter {
+	if len(vars)+1 > env.maxStackDepth {
+		return NewIter(&stackLimitError{})
+	}
 	env.codes = bc.codes
 	env.codeinfos = bc.codeinfos
 	env.push(v)
@@ -24,18 +27,21 @@ func (env *env) Next() (v any, ok bool) {
 	pc, callpc, index := env.pc, len(env.codes)-1, -1
 	backtrack, hasCtx := env.backtrack, env.ctx != context.Background()
 	defer func() {
-		env.pc, env.backtrack = pc, true
 		// A few value operations recurse in Go outside the opcode loop and panic
 		// with *allocLimitError when they get too deep or too large (Compare over a
-		// deeply nested value, for one). Recover it here so it surfaces as an error
-		// instead of escaping the run; anything else re-panics.
+		// deeply nested value, for one). Interpreter stack pushes use the same
+		// internal unwind for *stackLimitError. Recover both here so they surface as
+		// typed errors instead of escaping the run; anything else re-panics.
 		if r := recover(); r != nil {
-			if _, isAlloc := r.(*allocLimitError); !isAlloc {
+			switch r.(type) {
+			case *allocLimitError, *stackLimitError:
+			default:
 				panic(r)
 			}
 			pc, env.forks = len(env.codes), nil
-			v, ok = &allocLimitError{}, true
+			v, ok = r, true
 		}
+		env.pc, env.backtrack = pc, true
 	}()
 loop:
 	for ; pc < len(env.codes); pc++ {
@@ -96,11 +102,19 @@ loop:
 		case opappend:
 			i := env.index(code.v.([2]int))
 			x := env.pop()
+			xs := env.values[i].([]any)
+			// append can hold both old and new 16-byte-slot backing arrays during
+			// geometric growth. Bound that peak before it can make a large array
+			// whose transient footprint already exceeds the run limit.
+			if arrayAppendTooLarge(len(xs) + 1) {
+				err = &allocLimitError{}
+				break loop
+			}
 			if env.chargeBytes(16 + allocSize(x)) {
 				err = &allocLimitError{}
 				break loop
 			}
-			env.values[i] = append(env.values[i].([]any), x)
+			env.values[i] = append(xs, x)
 		case opfork:
 			if backtrack {
 				if err != nil {
@@ -192,7 +206,7 @@ loop:
 					err = &invalidPathError{v}
 					break loop
 				}
-				env.paths.push(pathValue{path: p, value: w})
+				env.pushpath(pathValue{path: p, value: w})
 			}
 		case opcall:
 			if backtrack {
@@ -214,50 +228,30 @@ loop:
 					break loop
 				}
 				env.push(w)
-				n := allocSize(w)
+				exceeded := false
 				if MaxAlloc > 0 {
-					switch name, _ := v[2].(string); name {
-					case "_match":
-						// _match builds nested capture objects the shallow
-						// meter cannot see; charge their real size, else a
-						// query collecting many matches allocates unbounded
-						// while the meter charges almost nothing.
-						n = matchResultSize(w)
-					case "fromjson":
-						// fromjson decodes a fresh nested tree the shallow
-						// meter cannot see; charge the deep size, else a query
-						// collecting many decodes of a deeply-nested string
-						// allocates unbounded.
-						n = deepSize(w)
-					case "transpose":
-						// transpose builds fresh inner arrays the shallow meter
-						// cannot see; charge their slots, else an N-by-2
-						// transpose collected in a loop allocates unbounded.
-						n = transposeResultSize(w)
-					case "setpath", "_setpath":
-						// setpath ( and |= / = ) copies a fresh spine the shallow
-						// meter cannot see; charge that spine, else collecting
-						// many deep-path setpaths allocates unbounded.
-						n = spineSize(w, args[0])
-					case "delpaths", "_delpaths":
-						// delpaths ( and del, and |= empty ) copies a fresh
-						// spine per deleted path the shallow meter cannot see;
-						// charge those spines from the input, else collecting
-						// many deep-path deletions allocates unbounded.
-						if s := delpathsSize(x, args[0]); s > n {
-							n = s
-						}
-					case "_multiply":
-						// map * map ( deepmerge ) builds fresh merged maps
-						// recursively the shallow meter cannot see; charge them,
-						// else collecting many deep merges allocates unbounded.
-						// ( 0 for non-map multiply, which keeps allocSize(w). )
-						if s := deepMergeSize(args[0], args[1], 0); s > 0 {
-							n = s
+					switch w.(type) {
+					case nil, bool, int, float64:
+						// The scalar hot path allocates nothing. Keep only the
+						// monotonic-budget check needed after a caught limit error.
+						exceeded = env.alloc > MaxAlloc
+					default:
+						n := allocSize(w)
+						exceeded = env.alloc > MaxAlloc
+						if n > 0 {
+							name, _ := v[2].(string)
+							if name != "input" && name != "inputs" {
+								switch w.(type) {
+								case []any, map[string]any:
+									exceeded = env.chargeFreshResult(w, x, args)
+								default:
+									exceeded = env.chargeBytes(n)
+								}
+							}
 						}
 					}
 				}
-				if env.chargeBytes(n) {
+				if exceeded {
 					err = &allocLimitError{}
 					break loop
 				}
@@ -268,13 +262,13 @@ loop:
 							err = &invalidPathError{x}
 							break loop
 						}
-						env.paths.push(pathValue{path: args[1], value: w})
+						env.pushpath(pathValue{path: args[1], value: w})
 					case "_slice":
 						if x = args[0]; !env.pathIntact(x) {
 							err = &invalidPathError{x}
 							break loop
 						}
-						env.paths.push(pathValue{
+						env.pushpath(pathValue{
 							path:  map[string]any{"start": args[2], "end": args[1]},
 							value: w,
 						})
@@ -284,7 +278,7 @@ loop:
 							break loop
 						}
 						for _, p := range args[0].([]any) {
-							env.paths.push(pathValue{path: p, value: w})
+							env.pushpath(pathValue{path: p, value: w})
 						}
 					}
 				}
@@ -294,6 +288,11 @@ loop:
 		case opcallrec:
 			pc, callpc, index = code.v.(int), -1, env.scopes.index
 			goto loop
+		case opcalltail:
+			env.tailDepth++
+			env.checkStackDepth(env.tailDepth + max(env.scopes.index, env.scopes.limit) + 1)
+			pc, callpc, index = code.v.(int), -1, env.scopes.index
+			goto loop
 		case oppushpc:
 			env.push([2]int{code.v.(int), env.scopes.index})
 		case opcallpc:
@@ -301,24 +300,30 @@ loop:
 			pc, callpc, index = xs[0], pc, xs[1]
 			goto loop
 		case opscope:
-			xs := code.v.([3]int)
+			xs := code.v.(scopeCode)
 			var saveindex, outerindex int
+			tailDepth := env.tailDepth
 			if index == env.scopes.index {
 				if callpc >= 0 {
 					saveindex = index
 				} else {
-					callpc, saveindex = env.popscope()
+					s := env.popscope()
+					callpc, saveindex, tailDepth = s.pc, s.saveindex, s.tailDepth
 				}
 			} else {
 				saveindex = env.scopes.index
 			}
 			if outerindex = index; outerindex >= 0 {
-				if s := env.scopes.data[outerindex].value; s.id == xs[0] {
+				if s := env.scopes.data[outerindex].value; s.id == xs.id {
 					outerindex = s.outerindex
 				}
 			}
-			env.scopes.push(scope{xs[0], env.offset, callpc, saveindex, outerindex})
-			env.offset += xs[1]
+			env.pushscope(scope{
+				id: xs.id, offset: env.offset, pc: callpc,
+				saveindex: saveindex, outerindex: outerindex, tailDepth: tailDepth,
+			})
+			env.checkStackDepth(env.offset + xs.variableCount)
+			env.offset += xs.variableCount
 			if env.offset > len(env.values) {
 				vs := make([]any, env.offset*2)
 				copy(vs, env.values)
@@ -328,7 +333,8 @@ loop:
 			if backtrack {
 				break loop
 			}
-			pc, env.scopes.index = env.popscope()
+			s := env.popscope()
+			pc, env.scopes.index, env.tailDepth = s.pc, s.saveindex, s.tailDepth
 			if env.scopes.empty() {
 				return env.pop(), true
 			}
@@ -399,6 +405,28 @@ loop:
 						err = e
 						break loop
 					}
+					exceeded := false
+					if MaxAlloc > 0 {
+						switch w.(type) {
+						case nil, bool, int, float64:
+							exceeded = env.alloc > MaxAlloc
+						default:
+							n := allocSize(w)
+							exceeded = env.alloc > MaxAlloc
+							if n > 0 {
+								switch w.(type) {
+								case []any, map[string]any:
+									exceeded = env.chargeFreshResult(w, nil, nil)
+								default:
+									exceeded = env.chargeBytes(n)
+								}
+							}
+						}
+					}
+					if exceeded {
+						err = &allocLimitError{}
+						break loop
+					}
 					env.push(w)
 					continue
 				}
@@ -415,15 +443,15 @@ loop:
 			}
 			env.push(xs[0].value)
 			if !env.paths.empty() && env.expdepth == 0 {
-				env.paths.push(xs[0])
+				env.pushpath(xs[0])
 			}
 		case opexpbegin:
 			env.expdepth++
 		case opexpend:
 			env.expdepth--
 		case oppathbegin:
-			env.paths.push(env.expdepth)
-			env.paths.push(pathValue{value: env.stack.top()})
+			env.pushpath(env.expdepth)
+			env.pushpath(pathValue{value: env.stack.top()})
 			env.expdepth = 0
 		case oppathend:
 			if backtrack {
@@ -434,8 +462,13 @@ loop:
 				err = &invalidPathError{v}
 				break loop
 			}
-			env.push(env.poppaths())
-			env.expdepth = env.paths.pop().(int)
+			paths := env.poppaths()
+			if env.charge(paths) {
+				err = &allocLimitError{}
+				break loop
+			}
+			env.push(paths)
+			env.expdepth = env.poppath().(int)
 		default:
 			panic(code.op)
 		}
@@ -451,24 +484,41 @@ loop:
 }
 
 func (env *env) push(v any) {
-	env.stack.push(v)
+	env.stack.push(v, env.maxStackDepth)
 }
 
 func (env *env) pop() any {
 	return env.stack.pop()
 }
 
-func (env *env) popscope() (int, int) {
+func (env *env) pushpath(v any) {
+	env.paths.push(v, env.maxStackDepth)
+}
+
+func (env *env) poppath() any {
+	return env.paths.pop()
+}
+
+func (env *env) pushscope(s scope) {
+	env.checkStackDepth(nextScopeDepth(env.scopes) + env.tailDepth)
+	env.scopes.push(s)
+}
+
+func (env *env) popscope() scope {
 	free := env.scopes.index > env.scopes.limit
 	s := env.scopes.pop()
 	if free {
 		env.offset = s.offset
 	}
-	return s.pc, s.saveindex
+	return s
 }
 
 func (env *env) pushfork(pc int) {
-	f := fork{pc: pc, offset: env.offset, expdepth: env.expdepth}
+	env.checkStackDepth(len(env.forks) + 1)
+	f := fork{
+		pc: pc, offset: env.offset, expdepth: env.expdepth,
+		tailDepth: env.tailDepth,
+	}
 	f.stackindex, f.stacklimit = env.stack.save()
 	f.scopeindex, f.scopelimit = env.scopes.save()
 	f.pathindex, f.pathlimit = env.paths.save()
@@ -479,8 +529,8 @@ func (env *env) pushfork(pc int) {
 func (env *env) popfork() int {
 	f := env.forks[len(env.forks)-1]
 	env.debugForks(f.pc, "<<<")
-	env.forks, env.offset, env.expdepth =
-		env.forks[:len(env.forks)-1], f.offset, f.expdepth
+	env.forks, env.offset, env.expdepth, env.tailDepth =
+		env.forks[:len(env.forks)-1], f.offset, f.expdepth, f.tailDepth
 	env.stack.restore(f.stackindex, f.stacklimit)
 	env.scopes.restore(f.scopeindex, f.scopelimit)
 	env.paths.restore(f.pathindex, f.pathlimit)
@@ -522,7 +572,7 @@ func (env *env) pathIntact(v any) bool {
 func (env *env) poppaths() []any {
 	xs := []any{}
 	for {
-		p := env.paths.pop().(pathValue)
+		p := env.poppath().(pathValue)
 		if p.path == nil {
 			break
 		}

--- a/execute.go
+++ b/execute.go
@@ -19,11 +19,24 @@ func (env *env) execute(bc *Code, v any, vars ...any) Iter {
 	return env
 }
 
-func (env *env) Next() (any, bool) {
+func (env *env) Next() (v any, ok bool) {
 	var err error
 	pc, callpc, index := env.pc, len(env.codes)-1, -1
 	backtrack, hasCtx := env.backtrack, env.ctx != context.Background()
-	defer func() { env.pc, env.backtrack = pc, true }()
+	defer func() {
+		env.pc, env.backtrack = pc, true
+		// A few value operations recurse in Go outside the opcode loop and panic
+		// with *allocLimitError when they get too deep or too large (Compare over a
+		// deeply nested value, for one). Recover it here so it surfaces as an error
+		// instead of escaping the run; anything else re-panics.
+		if r := recover(); r != nil {
+			if _, isAlloc := r.(*allocLimitError); !isAlloc {
+				panic(r)
+			}
+			pc, env.forks = len(env.codes), nil
+			v, ok = &allocLimitError{}, true
+		}
+	}()
 loop:
 	for ; pc < len(env.codes); pc++ {
 		env.debugState(pc, backtrack)
@@ -35,6 +48,10 @@ loop:
 				return env.ctx.Err(), true
 			default:
 			}
+		}
+		if MaxAlloc > 0 && env.overStackLimit() {
+			pc, env.forks = len(env.codes), nil
+			return &allocLimitError{}, true
 		}
 		switch code.op {
 		case opnop:
@@ -72,9 +89,18 @@ loop:
 				}
 			}
 			env.push(m)
+			if env.charge(m) {
+				err = &allocLimitError{}
+				break loop
+			}
 		case opappend:
 			i := env.index(code.v.([2]int))
-			env.values[i] = append(env.values[i].([]any), env.pop())
+			x := env.pop()
+			if env.chargeBytes(16 + allocSize(x)) {
+				err = &allocLimitError{}
+				break loop
+			}
+			env.values[i] = append(env.values[i].([]any), x)
 		case opfork:
 			if backtrack {
 				if err != nil {
@@ -188,6 +214,53 @@ loop:
 					break loop
 				}
 				env.push(w)
+				n := allocSize(w)
+				if MaxAlloc > 0 {
+					switch name, _ := v[2].(string); name {
+					case "_match":
+						// _match builds nested capture objects the shallow
+						// meter cannot see; charge their real size, else a
+						// query collecting many matches allocates unbounded
+						// while the meter charges almost nothing.
+						n = matchResultSize(w)
+					case "fromjson":
+						// fromjson decodes a fresh nested tree the shallow
+						// meter cannot see; charge the deep size, else a query
+						// collecting many decodes of a deeply-nested string
+						// allocates unbounded.
+						n = deepSize(w)
+					case "transpose":
+						// transpose builds fresh inner arrays the shallow meter
+						// cannot see; charge their slots, else an N-by-2
+						// transpose collected in a loop allocates unbounded.
+						n = transposeResultSize(w)
+					case "setpath", "_setpath":
+						// setpath ( and |= / = ) copies a fresh spine the shallow
+						// meter cannot see; charge that spine, else collecting
+						// many deep-path setpaths allocates unbounded.
+						n = spineSize(w, args[0])
+					case "delpaths", "_delpaths":
+						// delpaths ( and del, and |= empty ) copies a fresh
+						// spine per deleted path the shallow meter cannot see;
+						// charge those spines from the input, else collecting
+						// many deep-path deletions allocates unbounded.
+						if s := delpathsSize(x, args[0]); s > n {
+							n = s
+						}
+					case "_multiply":
+						// map * map ( deepmerge ) builds fresh merged maps
+						// recursively the shallow meter cannot see; charge them,
+						// else collecting many deep merges allocates unbounded.
+						// ( 0 for non-map multiply, which keeps allocSize(w). )
+						if s := deepMergeSize(args[0], args[1], 0); s > 0 {
+							n = s
+						}
+					}
+				}
+				if env.chargeBytes(n) {
+					err = &allocLimitError{}
+					break loop
+				}
 				if !env.paths.empty() && env.expdepth == 0 {
 					switch v[2].(string) {
 					case "_index":
@@ -276,6 +349,16 @@ loop:
 				if len(v) == 0 {
 					break loop
 				}
+				// .[] materializes a []pathValue of every element ( 32 bytes each )
+				// to drive the iteration. A per-array pre-check bounded one array
+				// but never charged it, so nested iteration of the same large array
+				// ( $a[] as $x | $a[] as $y | ... ) stacked these uncharged and
+				// reached hundreds of MB. Charge it to the run meter so nested and
+				// looped iterations accumulate and trip.
+				if env.chargeBytes(int64(len(v)) * 32) {
+					err = &allocLimitError{}
+					break loop
+				}
 				xs = make([]pathValue, len(v))
 				for i, v := range v {
 					xs[i] = pathValue{path: i, value: v}
@@ -286,6 +369,16 @@ loop:
 					break loop
 				}
 				if len(v) == 0 {
+					break loop
+				}
+				// .[] materializes a []pathValue of every element ( 32 bytes each )
+				// to drive the iteration. A per-array pre-check bounded one array
+				// but never charged it, so nested iteration of the same large array
+				// ( $a[] as $x | $a[] as $y | ... ) stacked these uncharged and
+				// reached hundreds of MB. Charge it to the run meter so nested and
+				// looped iterations accumulate and trip.
+				if env.chargeBytes(int64(len(v)) * 32) {
+					err = &allocLimitError{}
 					break loop
 				}
 				xs = make([]pathValue, len(v))

--- a/func.go
+++ b/func.go
@@ -810,6 +810,14 @@ func funcImplode(v any) any {
 	if !ok {
 		return &func0TypeError{"implode", v}
 	}
+	// The input array remains live while strings.Builder validates and encodes
+	// every interface value. Builder growth can temporarily retain old and new
+	// backing buffers, and each rune can occupy four output bytes. Cap that whole
+	// decode/encode working set before starting it; the returned string is still
+	// charged normally by the opcode meter.
+	if implodeWorkingSetTooLarge(len(vs)) {
+		return &allocLimitError{}
+	}
 	var sb strings.Builder
 	// Grow is only a capacity hint; cap it at the limit so a huge input array
 	// cannot force an upfront allocation past MaxAlloc before the per-rune check
@@ -1455,7 +1463,10 @@ func sortItems(name string, v, x any) ([]*sortItem, error) {
 	if len(vs) != len(xs) {
 		return nil, &func1WrapError{name, v, x, &lengthMismatchError{}}
 	}
-	if arrayTooLarge(len(vs)) {
+	// Sorting holds an 8-byte pointer slice plus one 32-byte sortItem per input
+	// and then a 16-byte result slot per input. Preflight the unavoidable peak so
+	// a single call cannot allocate past MaxAlloc before its result is charged.
+	if MaxAlloc > 0 && int64(len(vs)) > MaxAlloc/56 {
 		return nil, &allocLimitError{}
 	}
 	items := make([]*sortItem, len(vs))
@@ -2440,18 +2451,33 @@ func bigToFloat(x *big.Int) float64 {
 }
 
 func parseNumber(v json.Number) any {
-	if i, err := v.Int64(); err == nil && math.MinInt <= i && i <= math.MaxInt {
-		return int(i)
+	s := v.String()
+	if len(s) <= 20 {
+		if i, err := v.Int64(); err == nil && math.MinInt <= i && i <= math.MaxInt {
+			return int(i)
+		}
 	}
-	if strings.ContainsAny(v.String(), ".eE") {
+	// Decimal conversion uses superlinear scratch inside math/big. Mirror the
+	// encoder's 384-bytes-per-word safety factor in the reverse direction and
+	// reject by O(1) digit count before SetString starts work. Counting a sign or
+	// decimal syntax byte as a digit is deliberately conservative for absurdly
+	// large numbers and avoids a linear pre-scan on the attack path.
+	if MaxAlloc > 0 && len(s) > 20 {
+		digits := int64(len(s))
+		words := (digits + 18) / 19 // at most 19 decimal digits per 64-bit word
+		if words > MaxAlloc/384 {
+			panic(&allocLimitError{})
+		}
+	}
+	if strings.ContainsAny(s, ".eE") {
 		if f, err := v.Float64(); err == nil {
 			return f
 		}
 	}
-	if bi, ok := new(big.Int).SetString(v.String(), 10); ok {
+	if bi, ok := new(big.Int).SetString(s, 10); ok {
 		return bi
 	}
-	if strings.HasPrefix(v.String(), "-") {
+	if strings.HasPrefix(s, "-") {
 		return math.Inf(-1)
 	}
 	return math.Inf(1)

--- a/func.go
+++ b/func.go
@@ -15,9 +15,9 @@ import (
 	"regexp"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -330,7 +330,7 @@ func funcLength(v any) any {
 		}
 		return v[1:]
 	case string:
-		return len([]rune(v))
+		return utf8.RuneCountInString(v)
 	case []any:
 		return len(v)
 	case map[string]any:
@@ -351,12 +351,18 @@ func funcUtf8ByteLength(v any) any {
 func funcKeys(v any) any {
 	switch v := v.(type) {
 	case []any:
+		if arrayTooLarge(len(v)) {
+			return &allocLimitError{}
+		}
 		w := make([]any, len(v))
 		for i := range v {
 			w[i] = i
 		}
 		return w
 	case map[string]any:
+		if arrayTooLarge(len(v)) {
+			return &allocLimitError{}
+		}
 		w := make([]any, len(v))
 		for i, k := range keys(v) {
 			w[i] = k
@@ -378,18 +384,23 @@ func keys(v map[string]any) []string {
 	return w
 }
 
-func values(v any) ([]any, bool) {
+var errNotIterable = errors.New("not iterable")
+
+func values(v any) ([]any, error) {
 	switch v := v.(type) {
 	case []any:
-		return v, true
+		return v, nil
 	case map[string]any:
+		if arrayTooLarge(len(v)) {
+			return nil, &allocLimitError{}
+		}
 		vs := make([]any, len(v))
 		for i, k := range keys(v) {
 			vs[i] = v[k]
 		}
-		return vs, true
+		return vs, nil
 	default:
-		return nil, false
+		return nil, errNotIterable
 	}
 }
 
@@ -411,9 +422,12 @@ func funcHas(v, x any) any {
 }
 
 func funcAdd(v any) any {
-	vs, ok := values(v)
-	if !ok {
-		return &func0TypeError{"add", v}
+	vs, err := values(v)
+	if err != nil {
+		if err == errNotIterable {
+			return &func0TypeError{"add", v}
+		}
+		return err
 	}
 	return add(slices.Values(vs))
 }
@@ -433,26 +447,42 @@ func add(xs iter.Seq[any]) any {
 				continue
 			case *strings.Builder:
 				w.WriteString(x)
+				if MaxAlloc > 0 && int64(w.Len()) > MaxAlloc {
+					return &allocLimitError{}
+				}
 				continue
 			}
 		case []any:
 			switch w := v.(type) {
 			case nil:
+				if arrayTooLarge(len(x)) {
+					return &allocLimitError{}
+				}
 				s := make([]any, len(x))
 				copy(s, x)
 				v = s
 				continue
 			case []any:
-				v = append(w, x...)
+				w = append(w, x...)
+				if arrayTooLarge(len(w)) {
+					return &allocLimitError{}
+				}
+				v = w
 				continue
 			}
 		case map[string]any:
 			switch w := v.(type) {
 			case nil:
+				if MaxAlloc > 0 && int64(len(x))*24 > MaxAlloc {
+					return &allocLimitError{}
+				}
 				v = maps.Clone(x)
 				continue
 			case map[string]any:
 				maps.Copy(w, x)
+				if MaxAlloc > 0 && int64(len(w))*24 > MaxAlloc {
+					return &allocLimitError{}
+				}
 				continue
 			}
 		}
@@ -522,6 +552,9 @@ func funcReverse(v any) any {
 	if !ok {
 		return &func0TypeError{"reverse", v}
 	}
+	if arrayTooLarge(len(vs)) {
+		return &allocLimitError{}
+	}
 	ws := make([]any, len(vs))
 	for i, v := range vs {
 		ws[len(ws)-i-1] = v
@@ -530,6 +563,16 @@ func funcReverse(v any) any {
 }
 
 func funcContains(v, x any) any {
+	return containsDepth(v, x, 0)
+}
+
+// containsDepth is funcContains with a recursion-depth bound; contains/inside
+// recurse on nested arrays and objects, so a deeply nested value would overflow
+// the goroutine stack. Past the depth a value already exceeds the limit.
+func containsDepth(v, x any, depth int) any {
+	if MaxAlloc > 0 && (int64(depth)*16 > MaxAlloc || depth > maxRecursionDepth) {
+		panic(&allocLimitError{})
+	}
 	return binopTypeSwitch(v, x,
 		func(l, r int) any { return l == r },
 		func(l, r float64) any { return l == r },
@@ -539,7 +582,7 @@ func funcContains(v, x any) any {
 		R:
 			for _, r := range r {
 				for _, l := range l {
-					if funcContains(l, r) == true {
+					if containsDepth(l, r, depth+1) == true {
 						continue R
 					}
 				}
@@ -552,7 +595,7 @@ func funcContains(v, x any) any {
 				return false
 			}
 			for k, r := range r {
-				if l, ok := l[k]; !ok || funcContains(l, r) != true {
+				if l, ok := l[k]; !ok || containsDepth(l, r, depth+1) != true {
 					return false
 				}
 			}
@@ -571,6 +614,20 @@ func funcInside(v, x any) any {
 	return funcContains(x, v)
 }
 
+// matchAt reports whether xs equals the len(xs)-run of vs starting at i. It
+// compares element by element rather than reslicing vs on every position, which
+// boxed a fresh slice header into Compare each step and turned indices / index /
+// rindex over a large array into a big transient allocation ( tens of MB for one
+// match ). Elements are already interface values, so this allocates nothing.
+func matchAt(vs, xs []any, i int) bool {
+	for j := range xs {
+		if Compare(vs[i+j], xs[j]) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func funcIndices(v, x any) any {
 	return indexFunc("indices", v, x, indices)
 }
@@ -581,8 +638,11 @@ func indices(vs, xs []any) any {
 		return rs
 	}
 	for i := range len(vs) - len(xs) + 1 {
-		if Compare(vs[i:i+len(xs)], xs) == 0 {
+		if matchAt(vs, xs, i) {
 			rs = append(rs, i)
+			if arrayTooLarge(len(rs)) {
+				return &allocLimitError{}
+			}
 		}
 	}
 	return rs
@@ -594,7 +654,7 @@ func funcIndex(v, x any) any {
 			return nil
 		}
 		for i := range len(vs) - len(xs) + 1 {
-			if Compare(vs[i:i+len(xs)], xs) == 0 {
+			if matchAt(vs, xs, i) {
 				return i
 			}
 		}
@@ -608,7 +668,7 @@ func funcRindex(v, x any) any {
 			return nil
 		}
 		for i := len(vs) - len(xs); i >= 0; i-- {
-			if Compare(vs[i:i+len(xs)], xs) == 0 {
+			if matchAt(vs, xs, i) {
 				return i
 			}
 		}
@@ -629,6 +689,9 @@ func indexFunc(name string, v, x any, f func(_, _ []any) any) any {
 		}
 	case string:
 		if x, ok := x.(string); ok {
+			if arrayTooLarge(utf8.RuneCountInString(v)) || arrayTooLarge(utf8.RuneCountInString(x)) {
+				return &allocLimitError{}
+			}
 			return f(explode(v), explode(x))
 		}
 		return &func1TypeError{name, v, x}
@@ -726,11 +789,14 @@ func funcExplode(v any) any {
 	if !ok {
 		return &func0TypeError{"explode", v}
 	}
+	if arrayTooLarge(utf8.RuneCountInString(s)) {
+		return &allocLimitError{}
+	}
 	return explode(s)
 }
 
 func explode(s string) []any {
-	xs := make([]any, len([]rune(s)))
+	xs := make([]any, utf8.RuneCountInString(s))
 	var i int
 	for _, r := range s {
 		xs[i] = int(r)
@@ -745,13 +811,23 @@ func funcImplode(v any) any {
 		return &func0TypeError{"implode", v}
 	}
 	var sb strings.Builder
-	sb.Grow(len(vs))
+	// Grow is only a capacity hint; cap it at the limit so a huge input array
+	// cannot force an upfront allocation past MaxAlloc before the per-rune check
+	// below has a chance to fire.
+	grow := len(vs)
+	if MaxAlloc > 0 && int64(grow) > MaxAlloc {
+		grow = int(MaxAlloc)
+	}
+	sb.Grow(grow)
 	for _, v := range vs {
 		if r, ok := toInt(v); ok {
 			if 0 <= r && r <= utf8.MaxRune {
 				sb.WriteRune(rune(r))
 			} else {
 				sb.WriteRune(utf8.RuneError)
+			}
+			if MaxAlloc > 0 && int64(sb.Len()) > MaxAlloc {
+				return &allocLimitError{}
 			}
 		} else {
 			return &func0TypeError{"implode", vs}
@@ -769,6 +845,9 @@ func funcSplit(v, x any) any {
 	if !ok {
 		return &func0TypeError{"split", x}
 	}
+	if arrayTooLarge(strings.Count(s, t) + 1) {
+		return &allocLimitError{}
+	}
 	ss := strings.Split(s, t)
 	xs := make([]any, len(ss))
 	for i, s := range ss {
@@ -778,9 +857,12 @@ func funcSplit(v, x any) any {
 }
 
 func funcJoin(v, x any) any {
-	vs, ok := values(v)
-	if !ok {
-		return &func1TypeError{"join", v, x}
+	vs, err := values(v)
+	if err != nil {
+		if err == errNotIterable {
+			return &func1TypeError{"join", v, x}
+		}
+		return err
 	}
 	if len(vs) == 0 {
 		return ""
@@ -832,7 +914,11 @@ func funcASCIIUpcase(v any) any {
 }
 
 func funcToJSON(v any) any {
-	return jsonMarshal(v)
+	s, err := marshalBounded(v)
+	if err != nil {
+		return err
+	}
+	return s
 }
 
 func funcFromJSON(v any) any {
@@ -843,7 +929,16 @@ func funcFromJSON(v any) any {
 	var w any
 	dec := json.NewDecoder(strings.NewReader(s))
 	dec.UseNumber()
-	if err := dec.Decode(&w); err != nil {
+	if MaxAlloc > 0 {
+		var size int64
+		var err error
+		if w, err = decodeJSONLimited(dec, &size, 0); err != nil {
+			if _, ok := err.(*allocLimitError); ok {
+				return err
+			}
+			return &func0WrapError{"fromjson", v, err}
+		}
+	} else if err := dec.Decode(&w); err != nil {
 		return &func0WrapError{"fromjson", v, err}
 	}
 	if _, err := dec.Token(); err != io.EOF {
@@ -876,7 +971,11 @@ var htmlEscaper = strings.NewReplacer(
 func funcToHTML(v any) any {
 	switch x := funcToString(v).(type) {
 	case string:
-		return htmlEscaper.Replace(x)
+		s, ok := boundedReplace(htmlEscaper.Replace, x)
+		if !ok {
+			return &allocLimitError{}
+		}
+		return s
 	default:
 		return x
 	}
@@ -885,7 +984,13 @@ func funcToHTML(v any) any {
 func funcToURI(v any) any {
 	switch x := funcToString(v).(type) {
 	case string:
-		return strings.ReplaceAll(url.QueryEscape(x), "+", "%20")
+		s, ok := boundedReplace(func(s string) string {
+			return strings.ReplaceAll(url.QueryEscape(s), "+", "%20")
+		}, x)
+		if !ok {
+			return &allocLimitError{}
+		}
+		return s
 	default:
 		return x
 	}
@@ -910,9 +1015,7 @@ var csvEscaper = strings.NewReplacer(
 )
 
 func funcToCSV(v any) any {
-	return formatJoin("csv", v, ",", func(s string) string {
-		return `"` + csvEscaper.Replace(s) + `"`
-	})
+	return formatJoin("csv", v, ",", `"`, csvEscaper.Replace)
 }
 
 var tsvEscaper = strings.NewReplacer(
@@ -924,7 +1027,7 @@ var tsvEscaper = strings.NewReplacer(
 )
 
 func funcToTSV(v any) any {
-	return formatJoin("tsv", v, "\t", tsvEscaper.Replace)
+	return formatJoin("tsv", v, "\t", "", tsvEscaper.Replace)
 }
 
 var shEscaper = strings.NewReplacer(
@@ -936,35 +1039,79 @@ func funcToSh(v any) any {
 	if _, ok := v.([]any); !ok {
 		v = []any{v}
 	}
-	return formatJoin("sh", v, " ", func(s string) string {
-		return "'" + shEscaper.Replace(s) + "'"
-	})
+	return formatJoin("sh", v, " ", "'", shEscaper.Replace)
 }
 
-func formatJoin(typ string, v any, sep string, escape func(string) string) any {
+func formatJoin(typ string, v any, sep, quote string, escape func(string) string) any {
 	vs, ok := v.([]any)
 	if !ok {
 		return &func0TypeError{"@" + typ, v}
 	}
+	if arrayTooLarge(len(vs)) {
+		return &allocLimitError{}
+	}
 	ss := make([]string, len(vs))
+	var total int64
 	for i, v := range vs {
 		switch v := v.(type) {
 		case []any, map[string]any:
 			return &formatRowError{typ, v}
 		case string:
-			ss[i] = escape(v)
+			s, ok := boundedReplace(escape, v)
+			if !ok {
+				return &allocLimitError{}
+			}
+			ss[i] = quote + s + quote
 		default:
-			if s := jsonMarshal(v); s != "null" || typ == "sh" {
+			s, err := marshalBounded(v)
+			if err != nil {
+				return err
+			}
+			if s != "null" || typ == "sh" {
 				ss[i] = s
+			}
+		}
+		if MaxAlloc > 0 {
+			if total += int64(len(ss[i])) + 16; total > MaxAlloc {
+				return &allocLimitError{}
 			}
 		}
 	}
 	return strings.Join(ss, sep)
 }
 
+// boundedReplace applies a single-byte-replacement escaper to s, stopping once
+// the escaped output would pass MaxAlloc. The csv/tsv/sh escapers each replace
+// one byte at a time, so escaping fixed-size chunks and concatenating gives the
+// same result as escaping the whole string, while never building more than the
+// limit before the check fires. A quote-heavy field that would expand to many
+// times its size is caught here instead of after it is fully materialized.
+func boundedReplace(escape func(string) string, s string) (string, bool) {
+	if MaxAlloc <= 0 {
+		return escape(s), true
+	}
+	const chunk = 1 << 16
+	if len(s) <= chunk {
+		out := escape(s)
+		return out, int64(len(out)) <= MaxAlloc
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i += chunk {
+		j := min(i+chunk, len(s))
+		b.WriteString(escape(s[i:j]))
+		if int64(b.Len()) > MaxAlloc {
+			return "", false
+		}
+	}
+	return b.String(), true
+}
+
 func funcToBase64(v any) any {
 	switch x := funcToString(v).(type) {
 	case string:
+		if MaxAlloc > 0 && int64(base64.StdEncoding.EncodedLen(len(x))) > MaxAlloc {
+			return &allocLimitError{}
+		}
 		return base64.StdEncoding.EncodeToString([]byte(x))
 	default:
 		return x
@@ -1053,7 +1200,7 @@ func index(vs []any, i int) any {
 }
 
 func indexString(s string, i int) any {
-	l := len([]rune(s))
+	l := utf8.RuneCountInString(s)
 	i = clampIndex(i, -1, l)
 	if 0 <= i && i < l {
 		for _, r := range s {
@@ -1101,7 +1248,7 @@ func slice(vs []any, e, s any) any {
 
 func sliceString(v string, e, s any) any {
 	var start, end int
-	l := len([]rune(v))
+	l := utf8.RuneCountInString(v)
 	if s != nil {
 		if i, ok := toInt(s); ok {
 			start = clampIndex(i, 0, l)
@@ -1154,15 +1301,28 @@ func clampIndex(i, minimum, maximum int) int {
 	}
 }
 
-func funcFlatten(v any, args []any) any {
-	vs, ok := values(v)
-	if !ok {
-		return &func0TypeError{"flatten", v}
+func funcFlatten(v any, args []any) (r any) {
+	defer func() {
+		if e := recover(); e != nil {
+			if _, ok := e.(*allocLimitError); ok {
+				r = &allocLimitError{}
+				return
+			}
+			panic(e)
+		}
+	}()
+	vs, err := values(v)
+	if err != nil {
+		if err == errNotIterable {
+			return &func0TypeError{"flatten", v}
+		}
+		return err
 	}
 	var depth float64
 	if len(args) == 0 {
 		depth = -1
 	} else {
+		var ok bool
 		depth, ok = toFloat(args[0])
 		if !ok {
 			return &func0TypeError{"flatten", args[0]}
@@ -1171,15 +1331,23 @@ func funcFlatten(v any, args []any) any {
 			return &flattenDepthError{depth}
 		}
 	}
-	return flatten([]any{}, vs, depth)
+	return flatten([]any{}, vs, depth, 0)
 }
 
-func flatten(xs, vs []any, depth float64) []any {
+func flatten(xs, vs []any, depth float64, rec int) []any {
+	// bound the Go recursion depth so a deeply nested array cannot overflow the
+	// goroutine stack; a value this deep already exceeds the limit.
+	if MaxAlloc > 0 && (int64(rec)*16 > MaxAlloc || rec > maxRecursionDepth) {
+		panic(&allocLimitError{})
+	}
 	for _, v := range vs {
 		if vs, ok := v.([]any); ok && depth != 0 {
-			xs = flatten(xs, vs, depth-1)
+			xs = flatten(xs, vs, depth-1, rec+1)
 		} else {
 			xs = append(xs, v)
+			if arrayTooLarge(len(xs)) {
+				panic(&allocLimitError{})
+			}
 		}
 	}
 	return xs
@@ -1287,6 +1455,9 @@ func sortItems(name string, v, x any) ([]*sortItem, error) {
 	if len(vs) != len(xs) {
 		return nil, &func1WrapError{name, v, x, &lengthMismatchError{}}
 	}
+	if arrayTooLarge(len(vs)) {
+		return nil, &allocLimitError{}
+	}
 	items := make([]*sortItem, len(vs))
 	for i, v := range vs {
 		items[i] = &sortItem{v, xs[i]}
@@ -1309,6 +1480,9 @@ func sortBy(name string, v, x any) any {
 	items, err := sortItems(name, v, x)
 	if err != nil {
 		return err
+	}
+	if arrayTooLarge(len(items)) {
+		return &allocLimitError{}
 	}
 	rs := make([]any, len(items))
 	for i, x := range items {
@@ -1515,7 +1689,8 @@ func setpath(v, p, n any, a allocator) any {
 	if !ok {
 		return &func1TypeError{"setpath", v, p}
 	}
-	u, err := update(v, path, n, a)
+	var size int64
+	u, err := update(v, path, n, a, &size)
 	if err != nil {
 		return &func2WrapError{"setpath", v, p, n, err}
 	}
@@ -1544,13 +1719,14 @@ func delpaths(v, p any, a allocator) any {
 	//   jq -n "[0, 1, 2, 3] | delpaths([[1], [2]])" #=> [0, 3].
 	var empty struct{}
 	var err error
+	var size int64
 	u := v
 	for _, q := range paths {
 		path, ok := q.([]any)
 		if !ok {
 			return &func1WrapError{"delpaths", v, p, &expectedArrayError{q}}
 		}
-		u, err = update(u, path, empty, a)
+		u, err = update(u, path, empty, a, &size)
 		if err != nil {
 			return &func1WrapError{"delpaths", v, p, err}
 		}
@@ -1558,7 +1734,15 @@ func delpaths(v, p any, a allocator) any {
 	return deleteEmpty(u)
 }
 
-func update(v any, path []any, n any, a allocator) (any, error) {
+func update(v any, path []any, n any, a allocator, size *int64) (any, error) {
+	// update recurses once per path element ( updateObject/Index/Slice call back
+	// into update ), and the size counters only charge on the way UP - so a long
+	// path from input, which is not metered, would overflow the goroutine stack on
+	// the way DOWN before any charge fires. The path length is the recursion depth ,
+	// and a path this long builds a structure past the limit ( >= 16 bytes/level ).
+	if MaxAlloc > 0 && (int64(len(path))*16 > MaxAlloc || len(path) > maxRecursionDepth) {
+		return nil, &allocLimitError{}
+	}
 	if len(path) == 0 {
 		return n, nil
 	}
@@ -1566,9 +1750,9 @@ func update(v any, path []any, n any, a allocator) (any, error) {
 	case string:
 		switch v := v.(type) {
 		case nil:
-			return updateObject(nil, p, path[1:], n, a)
+			return updateObject(nil, p, path[1:], n, a, size)
 		case map[string]any:
-			return updateObject(v, p, path[1:], n, a)
+			return updateObject(v, p, path[1:], n, a, size)
 		case struct{}:
 			return v, nil
 		default:
@@ -1578,9 +1762,9 @@ func update(v any, path []any, n any, a allocator) (any, error) {
 		i, _ := toInt(p)
 		switch v := v.(type) {
 		case nil:
-			return updateArrayIndex(nil, i, path[1:], n, a)
+			return updateArrayIndex(nil, i, path[1:], n, a, size)
 		case []any:
-			return updateArrayIndex(v, i, path[1:], n, a)
+			return updateArrayIndex(v, i, path[1:], n, a, size)
 		case struct{}:
 			return v, nil
 		default:
@@ -1589,9 +1773,9 @@ func update(v any, path []any, n any, a allocator) (any, error) {
 	case map[string]any:
 		switch v := v.(type) {
 		case nil:
-			return updateArraySlice(nil, p, path[1:], n, a)
+			return updateArraySlice(nil, p, path[1:], n, a, size)
 		case []any:
-			return updateArraySlice(v, p, path[1:], n, a)
+			return updateArraySlice(v, p, path[1:], n, a, size)
 		case struct{}:
 			return v, nil
 		default:
@@ -1607,7 +1791,7 @@ func update(v any, path []any, n any, a allocator) (any, error) {
 	}
 }
 
-func updateObject(v map[string]any, k string, path []any, n any, a allocator) (any, error) {
+func updateObject(v map[string]any, k string, path []any, n any, a allocator, size *int64) (any, error) {
 	x, ok := v[k]
 	if !ok && n == struct{}{} {
 		if v == nil {
@@ -1615,7 +1799,7 @@ func updateObject(v map[string]any, k string, path []any, n any, a allocator) (a
 		}
 		return v, nil
 	}
-	u, err := update(x, path, n, a)
+	u, err := update(x, path, n, a, size)
 	if err != nil {
 		return nil, err
 	}
@@ -1623,13 +1807,18 @@ func updateObject(v map[string]any, k string, path []any, n any, a allocator) (a
 		v[k] = u
 		return v, nil
 	}
+	if MaxAlloc > 0 {
+		if *size += int64(len(v)+1)*24 + 16; *size > MaxAlloc {
+			return nil, &allocLimitError{}
+		}
+	}
 	w := a.makeObject(len(v) + 1)
 	maps.Copy(w, v)
 	w[k] = u
 	return w, nil
 }
 
-func updateArrayIndex(v []any, i int, path []any, n any, a allocator) (any, error) {
+func updateArrayIndex(v []any, i int, path []any, n any, a allocator, size *int64) (any, error) {
 	var x any
 	if j := clampIndex(i, -1, len(v)); j < 0 {
 		if n == struct{}{} {
@@ -1652,8 +1841,11 @@ func updateArrayIndex(v []any, i int, path []any, n any, a allocator) (any, erro
 		if i >= 0x20000000 {
 			return nil, &arrayIndexTooLargeError{i}
 		}
+		if MaxAlloc > 0 && int64(i+1)*16 > MaxAlloc {
+			return nil, &arrayIndexTooLargeError{i}
+		}
 	}
-	u, err := update(x, path, n, a)
+	u, err := update(x, path, n, a, size)
 	if err != nil {
 		return nil, err
 	}
@@ -1671,13 +1863,18 @@ func updateArrayIndex(v []any, i int, path []any, n any, a allocator) (any, erro
 	if i >= l {
 		l = i + 1
 	}
+	if MaxAlloc > 0 {
+		if *size += int64(l)*16 + 16; *size > MaxAlloc {
+			return nil, &allocLimitError{}
+		}
+	}
 	w := a.makeArray(l, c)
 	copy(w, v)
 	w[i] = u
 	return w, nil
 }
 
-func updateArraySlice(v []any, m map[string]any, path []any, n any, a allocator) (any, error) {
+func updateArraySlice(v []any, m map[string]any, path []any, n any, a allocator, size *int64) (any, error) {
 	s, ok := m["start"]
 	if !ok {
 		return nil, &expectedStartEndError{m}
@@ -1709,7 +1906,7 @@ func updateArraySlice(v []any, m map[string]any, path []any, n any, a allocator)
 		}
 		return v, nil
 	}
-	u, err := update(v[start:end], path, n, a)
+	u, err := update(v[start:end], path, n, a, size)
 	if err != nil {
 		return nil, err
 	}
@@ -1719,6 +1916,11 @@ func updateArraySlice(v []any, m map[string]any, path []any, n any, a allocator)
 		if len(u) == end-start && a.allocated(v) {
 			w = v
 		} else {
+			if MaxAlloc > 0 {
+				if *size += int64(len(v)-(end-start)+len(u))*16 + 16; *size > MaxAlloc {
+					return nil, &allocLimitError{}
+				}
+			}
 			w = a.makeArray(len(v)-(end-start)+len(u), 0)
 			copy(w, v[:start])
 			copy(w[start+len(u):], v[end:])
@@ -1730,6 +1932,11 @@ func updateArraySlice(v []any, m map[string]any, path []any, n any, a allocator)
 		if a.allocated(v) {
 			w = v
 		} else {
+			if MaxAlloc > 0 {
+				if *size += int64(len(v))*16 + 16; *size > MaxAlloc {
+					return nil, &allocLimitError{}
+				}
+			}
 			w = a.makeArray(len(v), 0)
 			copy(w, v)
 		}
@@ -1743,6 +1950,17 @@ func updateArraySlice(v []any, m map[string]any, path []any, n any, a allocator)
 }
 
 func deleteEmpty(v any) any {
+	return deleteEmptyDepth(v, 0)
+}
+
+// deleteEmptyDepth is deleteEmpty with a recursion-depth bound. delpaths walks
+// the whole result to strip empty markers, recursing on nesting; a deeply nested
+// sibling would overflow the goroutine stack. Past the depth the value already
+// exceeds the limit ; the interpreter's Next recovers the panic.
+func deleteEmptyDepth(v any, depth int) any {
+	if MaxAlloc > 0 && (int64(depth)*16 > MaxAlloc || depth > maxRecursionDepth) {
+		panic(&allocLimitError{})
+	}
 	switch v := v.(type) {
 	case struct{}:
 		return nil
@@ -1751,7 +1969,7 @@ func deleteEmpty(v any) any {
 			if w == struct{}{} {
 				delete(v, k)
 			} else {
-				v[k] = deleteEmpty(w)
+				v[k] = deleteEmptyDepth(w, depth+1)
 			}
 		}
 		return v
@@ -1759,7 +1977,7 @@ func deleteEmpty(v any) any {
 		var j int
 		for _, w := range v {
 			if w != struct{}{} {
-				v[j] = deleteEmpty(w)
+				v[j] = deleteEmptyDepth(w, depth+1)
 				j++
 			}
 		}
@@ -1809,6 +2027,9 @@ func funcTranspose(v any) any {
 		if k := len(vs); l < k {
 			l = k
 		}
+	}
+	if MaxAlloc > 0 && int64(l)*int64(len(vss))*16 > MaxAlloc {
+		return &allocLimitError{}
 	}
 	wss := make([][]any, l)
 	xs := make([]any, l)
@@ -1883,6 +2104,20 @@ func timeToEpoch(t time.Time) float64 {
 	return float64(t.Unix()) + float64(t.Nanosecond())/1e9
 }
 
+// boundedStrftime formats t with format but rejects a format long enough that
+// its expansion could pass MaxAlloc. timefmt.Format builds the whole result in
+// one pass, and directives such as %A / %B / %c expand a two-byte directive to
+// many bytes, so a big format taken from input ( strftime(.field) ) could
+// amplify far past the limit before the value meter, which sees only the
+// finished string, could charge it. The widest directive expands under 16x per
+// format byte, so this keeps a passing format's output under the limit.
+func boundedStrftime(t time.Time, format string) any {
+	if MaxAlloc > 0 && int64(len(format))*16 > MaxAlloc {
+		return &allocLimitError{}
+	}
+	return timefmt.Format(t, format)
+}
+
 func funcStrftime(v, x any) any {
 	if w, ok := toFloat(v); ok {
 		v = epochToArray(w, time.UTC)
@@ -1899,7 +2134,7 @@ func funcStrftime(v, x any) any {
 	if err != nil {
 		return &func1WrapError{"strftime", v, x, err}
 	}
-	return timefmt.Format(t, format)
+	return boundedStrftime(t, format)
 }
 
 func funcStrflocaltime(v, x any) any {
@@ -1918,7 +2153,7 @@ func funcStrflocaltime(v, x any) any {
 	if err != nil {
 		return &func1WrapError{"strflocaltime", v, x, err}
 	}
-	return timefmt.Format(t, format)
+	return boundedStrftime(t, format)
 }
 
 func funcStrptime(v, x any) any {
@@ -1929,6 +2164,13 @@ func funcStrptime(v, x any) any {
 	format, ok := x.(string)
 	if !ok {
 		return &func1TypeError{"strptime", v, x}
+	}
+	// timefmt.Parse reads the whole input and format into runes before matching,
+	// so a huge input ( which almost always fails on extra text anyway ) allocates
+	// several times its size. Reject one whose parse could pass MaxAlloc; real date
+	// strings are tiny, so only absurd inputs are refused.
+	if MaxAlloc > 0 && (int64(len(s))*8 > MaxAlloc || int64(len(format))*8 > MaxAlloc) {
+		return &allocLimitError{}
 	}
 	t, err := timefmt.Parse(s, format)
 	if err != nil {
@@ -1972,7 +2214,7 @@ func funcNow(any) any {
 	return timeToEpoch(time.Now())
 }
 
-func funcMatch(v, re, fs, testing any, cache *sync.Map) any {
+func funcMatch(v, re, fs, testing any, cache *reCache) any {
 	var name string
 	if testing == true {
 		name = "test"
@@ -2003,12 +2245,23 @@ func funcMatch(v, re, fs, testing any, cache *sync.Map) any {
 		return r.MatchString(s)
 	}
 	var n int
+	capped := false
 	if strings.ContainsRune(flags, 'g') {
 		n = -1
+		if MaxAlloc > 0 {
+			// bound the number of matches so the result array (a map per match,
+			// plus one per capture group) cannot exceed MaxAlloc.
+			if lim := int(MaxAlloc/int64(600+r.NumSubexp()*256)) + 1; lim > 0 {
+				n, capped = lim, true
+			}
+		}
 	} else {
 		n = 1
 	}
 	xs := r.FindAllStringSubmatchIndex(s, n)
+	if capped && len(xs) >= n {
+		return &allocLimitError{}
+	}
 	res, names := make([]any, len(xs)), r.SubexpNames()
 	for i, x := range xs {
 		captures := make([]any, (len(x)-2)/2)
@@ -2028,14 +2281,14 @@ func funcMatch(v, re, fs, testing any, cache *sync.Map) any {
 			}
 			captures[j-1] = map[string]any{
 				"name":   name,
-				"offset": len([]rune(s[:x[j*2]])),
-				"length": len([]rune(s[:x[j*2+1]])) - len([]rune(s[:x[j*2]])),
+				"offset": utf8.RuneCountInString(s[:x[j*2]]),
+				"length": utf8.RuneCountInString(s[:x[j*2+1]]) - utf8.RuneCountInString(s[:x[j*2]]),
 				"string": s[x[j*2]:x[j*2+1]],
 			}
 		}
 		res[i] = map[string]any{
-			"offset":   len([]rune(s[:x[0]])),
-			"length":   len([]rune(s[:x[1]])) - len([]rune(s[:x[0]])),
+			"offset":   utf8.RuneCountInString(s[:x[0]]),
+			"length":   utf8.RuneCountInString(s[:x[1]]) - utf8.RuneCountInString(s[:x[0]]),
 			"string":   s[x[0]:x[1]],
 			"captures": captures,
 		}
@@ -2043,9 +2296,18 @@ func funcMatch(v, re, fs, testing any, cache *sync.Map) any {
 	return res
 }
 
-func compileRegexp(re, flags string, cache *sync.Map) (*regexp.Regexp, error) {
+// reCache holds compiled regexps and tracks their approximate retained bytes,
+// so a run that generates millions of distinct patterns cannot grow the cache
+// without bound. When MaxAlloc is set and the cache is full, new patterns are
+// still compiled and returned, just not retained.
+type reCache struct {
+	m     sync.Map
+	bytes atomic.Int64
+}
+
+func compileRegexp(re, flags string, cache *reCache) (*regexp.Regexp, error) {
 	key := [2]string{re, flags}
-	if r, ok := cache.Load(key); ok {
+	if r, ok := cache.m.Load(key); ok {
 		return r.(*regexp.Regexp), nil
 	}
 	if strings.IndexFunc(flags, func(r rune) bool {
@@ -2063,7 +2325,11 @@ func compileRegexp(re, flags string, cache *sync.Map) (*regexp.Regexp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid regular expression %q: %s", re, err)
 	}
-	cache.Store(key, r)
+	if MaxAlloc <= 0 || cache.bytes.Load() < MaxAlloc {
+		if _, loaded := cache.m.LoadOrStore(key, r); !loaded {
+			cache.bytes.Add(int64(len(re))*128 + 1024)
+		}
+	}
 	return r, nil
 }
 
@@ -2165,10 +2431,12 @@ func bigToFloat(x *big.Int) float64 {
 	if x.IsInt64() {
 		return float64(x.Int64())
 	}
-	if f, err := strconv.ParseFloat(x.String(), 64); err == nil {
-		return f
-	}
-	return math.Inf(x.Sign())
+	// Convert through big.Float (a binary copy) rather than x.String(), whose
+	// base-10 conversion allocates large superlinear scratch inside math/big: a
+	// 10 MB integer divided by a small number reached ~300 MB, none of it seen by
+	// the value meter. Float64 already yields +/-Inf on overflow.
+	f, _ := new(big.Float).SetPrec(53).SetInt(x).Float64()
+	return f
 }
 
 func parseNumber(v json.Number) any {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,284 @@
+package gojq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	fuzzMaxAlloc       = int64(24 << 20)
+	fuzzMaxStackDepth  = 4096
+	fuzzContextTimeout = time.Second
+	fuzzWallTimeout    = 3 * time.Second
+	fuzzHeapAllowance  = uint64(256 << 20)
+	fuzzMaxProgramSize = 16 << 10
+	fuzzMaxJSONSize    = 1 << 20
+)
+
+// FuzzMeteredRun exercises the value meter and interpreter stack cap together.
+// Large inputs are represented by compact JSON recipes so that the corpus stays
+// small while native builtins still receive caller-owned arrays, strings, and
+// deeply nested objects.
+func FuzzMeteredRun(f *testing.F) {
+	deepPath := strings.Repeat(".a", 1024)
+	nestedArrays := strings.Repeat("[", 256) + "." + strings.Repeat("]", 256)
+
+	// Infinite/deep user-function recursion.
+	f.Add(`def f: f; f`, `null`)
+	f.Add(`def f: [f]; f`, `null`)
+	f.Add(`def f: (f, empty); f`, `null`)
+
+	// Value bombs and conversion working sets.
+	f.Add(`[range(1000000)]`, `null`)
+	f.Add(`[range(1e6)] | implode`, `null`)
+	f.Add(`"9" * 20000000 | tonumber`, `null`)
+
+	// String and structural amplification.
+	f.Add(`. * . * .`, `{"$fuzz":"string","n":2097152,"text":"ab"}`)
+	f.Add(`. + . | . + . | . + . | . + .`, `{"$fuzz":"string","n":2097152,"text":"ab"}`)
+	f.Add(nestedArrays, `null`)
+
+	// Input-proportional native builtins.
+	f.Add(`group_by(. % 97)`, `{"$fuzz":"numbers","n":200000}`)
+	f.Add(`unique_by(. % 97)`, `{"$fuzz":"numbers","n":200000}`)
+	f.Add(`sort_by(. % 97)`, `{"$fuzz":"numbers","n":200000}`)
+	f.Add(`[.[]] | transpose`, `{"$fuzz":"matrix","rows":384,"cols":384}`)
+
+	// Deep caller-owned input and a correspondingly deep path expression.
+	f.Add(deepPath, `{"$fuzz":"deep-object","depth":1024}`)
+
+	// A representative ordinary workload keeps successful execution in corpus.
+	f.Add(`[.status.conditions[] | select(.type=="Cond0") | .status][0]`,
+		`{"status":{"conditions":[{"type":"Cond0","status":"True"},{"type":"Cond1","status":"False"}]}}`)
+
+	f.Fuzz(func(t *testing.T, program, rawInput string) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Errorf("panic outside evaluator for program %q and input %q: %v\n%s",
+					program, rawInput, recovered, debug.Stack())
+			}
+		}()
+
+		// Parsing and compilation are outside the metered evaluator. Bound their
+		// fuzzed text so this target measures execution rather than parser size.
+		if len(program) > fuzzMaxProgramSize || len(rawInput) > fuzzMaxJSONSize {
+			return
+		}
+		input, ok := fuzzInput(rawInput)
+		if !ok {
+			return
+		}
+		query, err := Parse(program)
+		if err != nil {
+			return
+		}
+		code, err := Compile(query)
+		if err != nil {
+			return
+		}
+
+		oldAlloc, oldStackDepth := MaxAlloc, MaxStackDepth
+		MaxAlloc, MaxStackDepth = fuzzMaxAlloc, fuzzMaxStackDepth
+		restoreLimits := true
+		defer func() {
+			if restoreLimits {
+				MaxAlloc, MaxStackDepth = oldAlloc, oldStackDepth
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), fuzzContextTimeout)
+		defer cancel()
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		baselineHeap, peakHeap := mem.HeapInuse, mem.HeapInuse
+		resultc := make(chan fuzzRunResult, 1)
+		go drainFuzzRun(ctx, code, input, resultc)
+
+		wall := time.NewTimer(fuzzWallTimeout)
+		defer wall.Stop()
+		heapSample := time.NewTicker(25 * time.Millisecond)
+		defer heapSample.Stop()
+
+		for {
+			select {
+			case result := <-resultc:
+				runtime.ReadMemStats(&mem)
+				if mem.HeapInuse > peakHeap {
+					peakHeap = mem.HeapInuse
+				}
+				if result.recovered != nil {
+					t.Fatalf("evaluator panic for program %q and input %q: %v\n%s",
+						program, rawInput, result.recovered, result.stack)
+				}
+				if result.badError != nil {
+					t.Fatalf("unexpected runtime/OOM error for program %q and input %q: %T: %v",
+						program, rawInput, result.badError, result.badError)
+				}
+				if peakHeap > baselineHeap && peakHeap-baselineHeap > fuzzHeapAllowance {
+					t.Fatalf("metered run grew HeapInuse by %d MiB (allowance %d MiB) for program %q and input %q",
+						(peakHeap-baselineHeap)>>20, fuzzHeapAllowance>>20, program, rawInput)
+				}
+				return
+			case <-heapSample.C:
+				runtime.ReadMemStats(&mem)
+				if mem.HeapInuse > peakHeap {
+					peakHeap = mem.HeapInuse
+				}
+			case <-wall.C:
+				cancel()
+				// A stuck evaluator may still be reading the global allocation
+				// limit. Leave it enabled while the failing worker exits.
+				restoreLimits = false
+				t.Fatalf("metered run exceeded the %v hard wall for program %q and input %q",
+					fuzzWallTimeout, program, rawInput)
+			}
+		}
+	})
+}
+
+type fuzzRunResult struct {
+	recovered any
+	stack     []byte
+	badError  error
+}
+
+func drainFuzzRun(ctx context.Context, code *Code, input any, resultc chan<- fuzzRunResult) {
+	result := fuzzRunResult{}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result.recovered = recovered
+			result.stack = debug.Stack()
+		}
+		resultc <- result
+	}()
+	iter := code.RunWithContext(ctx, input)
+	for {
+		value, ok := iter.Next()
+		if !ok {
+			return
+		}
+		if err, isError := value.(error); isError && fuzzUnexpectedRuntimeError(err) {
+			result.badError = err
+			return
+		}
+	}
+}
+
+func fuzzUnexpectedRuntimeError(err error) bool {
+	// Allocation/stack limits, context cancellation, and ordinary jq errors
+	// are all valid terminal outcomes. A Go runtime error is never one.
+	var runtimeError runtime.Error
+	if errors.As(err, &runtimeError) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	switch err.(type) {
+	case *allocLimitError, *stackLimitError:
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"runtime error:",
+		"fatal error:",
+		"out of memory",
+		"cannot allocate memory",
+		"stack overflow",
+		"goroutine stack exceeds",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// fuzzInput decodes ordinary JSON or expands one of the compact, bounded input
+// recipes used by the seed corpus. Mutations of the recipe fields explore sizes
+// and shapes without allowing the harness itself to allocate without a ceiling.
+func fuzzInput(raw string) (any, bool) {
+	var input any
+	if err := json.Unmarshal([]byte(raw), &input); err != nil {
+		return nil, false
+	}
+	object, isObject := input.(map[string]any)
+	if !isObject {
+		return input, true
+	}
+	kind, _ := object["$fuzz"].(string)
+	switch kind {
+	case "numbers":
+		n, ok := fuzzRecipeInt(object, "n", 750000)
+		if !ok {
+			return input, true
+		}
+		numbers := make([]any, n)
+		for i := range numbers {
+			numbers[i] = float64(i % 4096)
+		}
+		return numbers, true
+	case "matrix":
+		rows, rowsOK := fuzzRecipeInt(object, "rows", 1<<18)
+		cols, colsOK := fuzzRecipeInt(object, "cols", 1<<18)
+		if !rowsOK || !colsOK {
+			return input, true
+		}
+		const maxCells = 1 << 18
+		if rows > 0 && cols > maxCells/rows {
+			cols = maxCells / rows
+		}
+		matrix := make([]any, rows)
+		for row := range matrix {
+			values := make([]any, cols)
+			for col := range values {
+				values[col] = float64((row + col) % 4096)
+			}
+			matrix[row] = values
+		}
+		return matrix, true
+	case "string":
+		n, ok := fuzzRecipeInt(object, "n", 8<<20)
+		if !ok {
+			return input, true
+		}
+		text, _ := object["text"].(string)
+		if text == "" {
+			text = "x"
+		}
+		repeated := strings.Repeat(text, (n+len(text)-1)/len(text))
+		return repeated[:n], true
+	case "deep-object":
+		depth, ok := fuzzRecipeInt(object, "depth", fuzzMaxStackDepth)
+		if !ok {
+			return input, true
+		}
+		var nested any = "leaf"
+		for range depth {
+			nested = map[string]any{"a": nested}
+		}
+		return nested, true
+	default:
+		return input, true
+	}
+}
+
+func fuzzRecipeInt(object map[string]any, key string, maximum int) (int, bool) {
+	value, ok := object[key].(float64)
+	if !ok {
+		return 0, false
+	}
+	if value <= 0 {
+		return 0, true
+	}
+	if value >= float64(maximum) {
+		return maximum, true
+	}
+	return int(value), true
+}

--- a/memlimit.go
+++ b/memlimit.go
@@ -1,0 +1,350 @@
+package gojq
+
+import (
+	"encoding/json"
+	"math/big"
+	"reflect"
+)
+
+// MaxAlloc bounds the total number of bytes a single query execution may
+// allocate for its values. Zero, the default, disables the limit and keeps
+// the original behaviour. Set it once before running queries.
+var MaxAlloc int64
+
+type allocLimitError struct{}
+
+func (*allocLimitError) Error() string {
+	return "value allocation exceeds the configured memory limit"
+}
+
+// maxRecursionDepth caps the Go-recursive builtins ( compare, contains, encode,
+// flatten, deleteEmpty, update, deepmerge, and the JSON decoder ) independently
+// of MaxAlloc. Their per-level depth bounds scale with MaxAlloc, so a very large
+// MaxAlloc plus a deeply nested input would let the recursion overflow the
+// goroutine stack ( a fatal, uncatchable crash ). This hard cap converts that
+// into a clean allocation error at any MaxAlloc. At MaxAlloc <= ~4 MiB the
+// per-level bound ( MaxAlloc/16 ) is the binding one, so this never changes
+// behavior there; it only fires far past any depth a real input reaches.
+const maxRecursionDepth = 1 << 19
+
+// allocSize is a cheap, non-recursive estimate of a value's byte size,
+// used only by the allocation meter.
+func allocSize(v any) int64 {
+	switch t := v.(type) {
+	case string:
+		return int64(len(t)) + 16 // string header (ptr + len)
+	case []any:
+		return int64(len(t))*16 + 16
+	case map[string]any:
+		// A Go map has a ~320-byte minimum ( hmap header + a full first
+		// bucket ) that len*24 missed entirely, so a chain or collection of
+		// tiny 1-key maps ran ~6x over the limit. Charge that base plus ~40
+		// per entry ( bucket slot + copied key header ); key string content is
+		// still charged separately where the key is built.
+		return int64(len(t))*40 + 320
+	case *big.Int:
+		return int64(len(t.Bits()))*8 + 16
+	case json.Number:
+		return int64(len(t)) + 16 // a numeric string, like string
+	default:
+		// scalars (int, float64, bool, nil) are tiny and transient - they
+		// cannot grow a run out of memory, so the gas meter does not count
+		// them. this keeps a streaming query that produces many scalars, such
+		// as `reduce range(N) as $x (0; . + 1)`, from tripping the limit while
+		// holding almost nothing live. retained scalars in an array still cost
+		// their 16-byte slot, charged at opappend.
+		return 0
+	}
+}
+
+// matchResultSize is the deep byte size of a _match result: an array of match
+// objects, each holding a captures array of capture objects. allocSize is
+// shallow, so without accounting for the nested captures a query that collects
+// many matches ( each with many capture groups ) allocates far past MaxAlloc
+// while the meter, seeing only the top-level array, charges almost nothing. The
+// shape is fixed ( array -> match map -> captures array -> capture map ), so
+// this is a bounded walk, not open recursion.
+func matchResultSize(w any) int64 {
+	res, ok := w.([]any)
+	if !ok {
+		return allocSize(w)
+	}
+	n := allocSize(res)
+	for _, m := range res {
+		mm, ok := m.(map[string]any)
+		if !ok {
+			n += allocSize(m)
+			continue
+		}
+		n += allocSize(mm)
+		if caps, ok := mm["captures"].([]any); ok {
+			n += allocSize(caps)
+			for _, c := range caps {
+				n += allocSize(c)
+			}
+		}
+	}
+	return n
+}
+
+// deepSize is the total byte size of a value including everything nested. It is
+// used to charge builtins that return a freshly decoded tree the shallow meter
+// cannot see ( fromjson ): decodeJSONLimited bounds a single decode, but the
+// result is otherwise charged only at its top level, so collecting many decodes
+// of a deeply-nested string allocated gigabytes while the meter saw almost
+// nothing. It walks iteratively so an arbitrarily deep result cannot overflow
+// the goroutine stack, and must only be called on trees ( no shared references,
+// which a JSON decode never produces ), else a shared node is counted per path.
+func deepSize(v any) int64 {
+	var total int64
+	stack := []any{v}
+	for len(stack) > 0 {
+		x := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		total += allocSize(x)
+		switch x := x.(type) {
+		case []any:
+			stack = append(stack, x...)
+		case map[string]any:
+			for key, val := range x {
+				total += int64(len(key)) + 16 // key string copied into the object
+				stack = append(stack, val)
+			}
+		}
+	}
+	return total
+}
+
+// transposeResultSize is the byte size of a transpose result: an outer array of
+// freshly-made inner arrays whose elements are references into the input. The
+// shallow meter charges only the outer array, so an N-by-2 transpose ( two wide
+// inner arrays ) collected in a loop allocated hundreds of MB while the meter
+// saw ~48 bytes each. This charges the inner arrays' slots too, but stops at the
+// elements ( they are refs, and recursing could revisit a shared sub-value ).
+func transposeResultSize(w any) int64 {
+	outer, ok := w.([]any)
+	if !ok {
+		return allocSize(w)
+	}
+	n := allocSize(outer)
+	for _, inner := range outer {
+		n += allocSize(inner)
+	}
+	return n
+}
+
+// spineSize is the byte size of the fresh spine setpath copies: the containers
+// from the root down to the target along the path. setpath ( and |= / = ) copy
+// only this spine and share the rest of the input by reference, so charging the
+// whole result ( deepSize ) would over-count the shared branches and reject
+// legitimate multi-assignments; charging only the top ( allocSize ) misses the
+// deep spine, so collecting many deep-path setpaths allocated GB. Walking one
+// path is DAG-safe ( no branching ) and matches what update actually allocates.
+func spineSize(w, p any) int64 {
+	path, ok := p.([]any)
+	if !ok {
+		return allocSize(w)
+	}
+	var total int64
+	cur := w
+	for _, k := range path {
+		switch cur.(type) {
+		case []any, map[string]any:
+			total += allocSize(cur)
+		default:
+			return total
+		}
+		cur = funcIndex2(nil, cur, k)
+		if _, isErr := cur.(error); isErr {
+			return total
+		}
+	}
+	return total
+}
+
+// delpathsSize is the byte size of the fresh spines delpaths copies. delpaths
+// copies each container from the root down to a deleted path, sharing the rest
+// of the input by reference - the same copy-on-write as setpath. The shallow
+// meter charges only the top of the result, so collecting many deep-path
+// deletions ( del(f) over a deep value ) allocated unbounded memory while the
+// meter saw almost nothing. It charges the spines from the input, since the
+// result no longer holds the deleted paths.
+//
+// delpaths shares one allocator across all its paths, so it copies each
+// container at most once; this charges the UNION of the path spines, deduping
+// containers by identity the same way the allocator does. Summing each path's
+// spine separately would be quadratic for a wide sibling delete like del(.[])
+// ( every path starts at the same root ) and would falsely reject it.
+func delpathsSize(v, p any) int64 {
+	paths, ok := p.([]any)
+	if !ok {
+		return 0
+	}
+	seen := map[uintptr]struct{}{}
+	var total int64
+	for _, q := range paths {
+		path, ok := q.([]any)
+		if !ok {
+			continue
+		}
+		cur := v
+	walk:
+		for _, k := range path {
+			switch cur.(type) {
+			case []any, map[string]any:
+				addr := reflect.ValueOf(cur).Pointer()
+				if _, ok := seen[addr]; !ok {
+					seen[addr] = struct{}{}
+					total += allocSize(cur)
+				}
+			default:
+				break walk
+			}
+			cur = funcIndex2(nil, cur, k)
+			if _, isErr := cur.(error); isErr {
+				break walk
+			}
+		}
+	}
+	return total
+}
+
+// deepMergeSize is the byte size of the fresh maps that map * map ( deepmerge )
+// builds. deepMergeObjectsLimited recurses only where both sides hold a map, so
+// it copies a spine of new maps and shares the rest by reference; charging the
+// whole result would over-count the shared branches, and charging only the top
+// misses the recursion, so collecting many deep merges allocated GB. This walks
+// the same overlap the merge does, so it charges exactly the new maps. It is
+// bounded because the merge already refused ( via its own size counter ) any
+// result larger than MaxAlloc, and it returns 0 for non-map operands ( ordinary
+// numeric / string multiply, charged by allocSize as before ).
+//
+// The merged map holds the UNION of the two key sets ( len(lm) plus the keys
+// only in rm ), so it is charged as such. Charging len(lm)+len(rm) double-counted
+// the shared keys and falsely rejected a large merge whose sides overlap heavily
+// ( a 55k-key self-merge, ~2.5 MB, was rejected at a 4 MiB limit ).
+func deepMergeSize(l, r any, depth int) int64 {
+	if depth > maxRecursionDepth {
+		return 0
+	}
+	lm, lok := l.(map[string]any)
+	rm, rok := r.(map[string]any)
+	if !lok || !rok {
+		return 0
+	}
+	n := int64(len(lm))*40 + 320
+	for k, rv := range rm {
+		lv, inL := lm[k]
+		if !inL {
+			n += 40 // a key only in rm adds one entry to the merged map
+			continue
+		}
+		if lvm, ok := lv.(map[string]any); ok {
+			if rvm, ok := rv.(map[string]any); ok {
+				n += deepMergeSize(lvm, rvm, depth+1)
+			}
+		}
+	}
+	return n
+}
+
+// chargeBytes adds n to the running total and reports whether the limit has
+// now been exceeded.
+func (env *env) chargeBytes(n int64) bool {
+	if MaxAlloc <= 0 {
+		return false
+	}
+	env.alloc += n
+	return env.alloc > MaxAlloc
+}
+
+// charge adds v's size to the running total and reports whether the limit
+// has now been exceeded.
+func (env *env) charge(v any) bool {
+	return env.chargeBytes(allocSize(v))
+}
+
+// arrayTooLarge reports whether a []any of n elements would exceed MaxAlloc.
+// Used to pre-check builtins that allocate an input-proportional array in one make().
+func arrayTooLarge(n int) bool {
+	return MaxAlloc > 0 && int64(n)*16 > MaxAlloc
+}
+
+// overStackLimit reports whether the interpreter's own live stacks exceed
+// MaxAlloc. Deep or infinite recursion, such as `def f: [f]; f`, grows these
+// stacks without ever completing a value, so the value meter never charges it.
+// The per-block sizes match the interpreter structs (stack/paths block, scope
+// block, fork).
+func (env *env) overStackLimit() bool {
+	return int64(len(env.stack.data))*24+
+		int64(len(env.paths.data))*24+
+		int64(len(env.scopes.data))*48+
+		int64(len(env.values))*16+
+		int64(len(env.forks))*72 > MaxAlloc
+}
+
+// decodeJSONLimited decodes one JSON value from dec, tracking the cumulative
+// shallow size of the structure it builds and erroring once that size passes
+// MaxAlloc. It mirrors json.Decoder.Decode under UseNumber, so a huge document
+// cannot be materialized in one shot before the value meter would see it.
+// Sizes match allocSize: 16 bytes per array slot, 40 per object entry (24 map
+// bucket + a 16-byte string header for the key), plus each value's own footprint.
+func decodeJSONLimited(dec *json.Decoder, size *int64, depth int) (any, error) {
+	if MaxAlloc > 0 && depth > maxRecursionDepth {
+		return nil, &allocLimitError{}
+	}
+	t, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch t := t.(type) {
+	case json.Delim:
+		switch t {
+		case '[':
+			arr := []any{}
+			for dec.More() {
+				if *size += 16; *size > MaxAlloc {
+					return nil, &allocLimitError{}
+				}
+				v, err := decodeJSONLimited(dec, size, depth+1)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, v)
+			}
+			_, err := dec.Token() // consume ]
+			return arr, err
+		case '{':
+			obj := map[string]any{}
+			for dec.More() {
+				key, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				k := key.(string)
+				if *size += int64(len(k)) + 40; *size > MaxAlloc {
+					return nil, &allocLimitError{}
+				}
+				v, err := decodeJSONLimited(dec, size, depth+1)
+				if err != nil {
+					return nil, err
+				}
+				obj[k] = v
+			}
+			_, err := dec.Token() // consume }
+			return obj, err
+		default:
+			return nil, &json.SyntaxError{}
+		}
+	case string:
+		*size += int64(len(t)) + 16
+	case json.Number:
+		*size += int64(len(t)) + 16
+	default: // bool, nil
+		*size += 16
+	}
+	if *size > MaxAlloc {
+		return nil, &allocLimitError{}
+	}
+	return t, nil
+}

--- a/memlimit.go
+++ b/memlimit.go
@@ -57,195 +57,119 @@ func allocSize(v any) int64 {
 	}
 }
 
-// matchResultSize is the deep byte size of a _match result: an array of match
-// objects, each holding a captures array of capture objects. allocSize is
-// shallow, so without accounting for the nested captures a query that collects
-// many matches ( each with many capture groups ) allocates far past MaxAlloc
-// while the meter, seeing only the top-level array, charges almost nothing. The
-// shape is fixed ( array -> match map -> captures array -> capture map ), so
-// this is a bounded walk, not open recursion.
-func matchResultSize(w any) int64 {
-	res, ok := w.([]any)
-	if !ok {
-		return allocSize(w)
+// chargeFreshResult charges all storage a native callback freshly allocated for
+// result. Containers reachable from input or args are borrowed by identity and
+// pruned, so copy-on-write spines are charged while their shared branches remain
+// free. The iterative walk handles arbitrary depth and shared-reference DAGs;
+// every native callback, including future and custom callbacks, inherits it at
+// the single opcall return boundary.
+func (env *env) chargeFreshResult(result, input any, args []any) bool {
+	if MaxAlloc <= 0 {
+		return false
 	}
-	n := allocSize(res)
-	for _, m := range res {
-		mm, ok := m.(map[string]any)
-		if !ok {
-			n += allocSize(m)
-			continue
+	switch result.(type) {
+	case []any, map[string]any:
+		// Compound results need the ownership walk below.
+	default:
+		// Scalars cost zero; strings, numbers, and big integers are shallow
+		// leaves. Keep this common path allocation-free.
+		return env.charge(result)
+	}
+	// An allocator-backed update can return the same container it received and
+	// mutate below that root. Avoid an O(size(input)) seed on every such update,
+	// but retain the old shallow charge rather than treating the alias as free.
+	if addr, _ := containerAddr(result); addr != 0 {
+		if inputAddr, _ := containerAddr(input); addr == inputAddr {
+			return env.charge(result)
 		}
-		n += allocSize(mm)
-		if caps, ok := mm["captures"].([]any); ok {
-			n += allocSize(caps)
-			for _, c := range caps {
-				n += allocSize(c)
+		for _, arg := range args {
+			if argAddr, _ := containerAddr(arg); addr == argAddr {
+				return env.charge(result)
 			}
 		}
 	}
-	return n
+	seen := map[uintptr]struct{}{}
+	markContainers(input, seen)
+	for _, arg := range args {
+		markContainers(arg, seen)
+	}
+	stack := []any{result}
+	for len(stack) > 0 {
+		x := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		switch x := x.(type) {
+		case []any:
+			addr := reflect.ValueOf(x).Pointer()
+			if _, ok := seen[addr]; ok {
+				continue
+			}
+			seen[addr] = struct{}{}
+			if env.chargeBytes(allocSize(x)) {
+				return true
+			}
+			stack = append(stack, x...)
+		case map[string]any:
+			addr := reflect.ValueOf(x).Pointer()
+			if _, ok := seen[addr]; ok {
+				continue
+			}
+			seen[addr] = struct{}{}
+			if env.chargeBytes(allocSize(x)) {
+				return true
+			}
+			for key, value := range x {
+				if env.chargeBytes(int64(len(key)) + 16) {
+					return true
+				}
+				stack = append(stack, value)
+			}
+		default:
+			if env.charge(x) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
-// deepSize is the total byte size of a value including everything nested. It is
-// used to charge builtins that return a freshly decoded tree the shallow meter
-// cannot see ( fromjson ): decodeJSONLimited bounds a single decode, but the
-// result is otherwise charged only at its top level, so collecting many decodes
-// of a deeply-nested string allocated gigabytes while the meter saw almost
-// nothing. It walks iteratively so an arbitrarily deep result cannot overflow
-// the goroutine stack, and must only be called on trees ( no shared references,
-// which a JSON decode never produces ), else a shared node is counted per path.
-func deepSize(v any) int64 {
-	var total int64
+func containerAddr(v any) (uintptr, bool) {
+	switch v := v.(type) {
+	case []any:
+		return reflect.ValueOf(v).Pointer(), true
+	case map[string]any:
+		return reflect.ValueOf(v).Pointer(), true
+	default:
+		return 0, false
+	}
+}
+
+// markContainers records all container identities reachable from v. A result
+// node with one of these identities existed before the callback, so its whole
+// subtree is shared input rather than newly allocated output.
+func markContainers(v any, seen map[uintptr]struct{}) {
 	stack := []any{v}
 	for len(stack) > 0 {
 		x := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		total += allocSize(x)
 		switch x := x.(type) {
 		case []any:
+			addr := reflect.ValueOf(x).Pointer()
+			if _, ok := seen[addr]; ok {
+				continue
+			}
+			seen[addr] = struct{}{}
 			stack = append(stack, x...)
 		case map[string]any:
-			for key, val := range x {
-				total += int64(len(key)) + 16 // key string copied into the object
-				stack = append(stack, val)
+			addr := reflect.ValueOf(x).Pointer()
+			if _, ok := seen[addr]; ok {
+				continue
+			}
+			seen[addr] = struct{}{}
+			for _, value := range x {
+				stack = append(stack, value)
 			}
 		}
 	}
-	return total
-}
-
-// transposeResultSize is the byte size of a transpose result: an outer array of
-// freshly-made inner arrays whose elements are references into the input. The
-// shallow meter charges only the outer array, so an N-by-2 transpose ( two wide
-// inner arrays ) collected in a loop allocated hundreds of MB while the meter
-// saw ~48 bytes each. This charges the inner arrays' slots too, but stops at the
-// elements ( they are refs, and recursing could revisit a shared sub-value ).
-func transposeResultSize(w any) int64 {
-	outer, ok := w.([]any)
-	if !ok {
-		return allocSize(w)
-	}
-	n := allocSize(outer)
-	for _, inner := range outer {
-		n += allocSize(inner)
-	}
-	return n
-}
-
-// spineSize is the byte size of the fresh spine setpath copies: the containers
-// from the root down to the target along the path. setpath ( and |= / = ) copy
-// only this spine and share the rest of the input by reference, so charging the
-// whole result ( deepSize ) would over-count the shared branches and reject
-// legitimate multi-assignments; charging only the top ( allocSize ) misses the
-// deep spine, so collecting many deep-path setpaths allocated GB. Walking one
-// path is DAG-safe ( no branching ) and matches what update actually allocates.
-func spineSize(w, p any) int64 {
-	path, ok := p.([]any)
-	if !ok {
-		return allocSize(w)
-	}
-	var total int64
-	cur := w
-	for _, k := range path {
-		switch cur.(type) {
-		case []any, map[string]any:
-			total += allocSize(cur)
-		default:
-			return total
-		}
-		cur = funcIndex2(nil, cur, k)
-		if _, isErr := cur.(error); isErr {
-			return total
-		}
-	}
-	return total
-}
-
-// delpathsSize is the byte size of the fresh spines delpaths copies. delpaths
-// copies each container from the root down to a deleted path, sharing the rest
-// of the input by reference - the same copy-on-write as setpath. The shallow
-// meter charges only the top of the result, so collecting many deep-path
-// deletions ( del(f) over a deep value ) allocated unbounded memory while the
-// meter saw almost nothing. It charges the spines from the input, since the
-// result no longer holds the deleted paths.
-//
-// delpaths shares one allocator across all its paths, so it copies each
-// container at most once; this charges the UNION of the path spines, deduping
-// containers by identity the same way the allocator does. Summing each path's
-// spine separately would be quadratic for a wide sibling delete like del(.[])
-// ( every path starts at the same root ) and would falsely reject it.
-func delpathsSize(v, p any) int64 {
-	paths, ok := p.([]any)
-	if !ok {
-		return 0
-	}
-	seen := map[uintptr]struct{}{}
-	var total int64
-	for _, q := range paths {
-		path, ok := q.([]any)
-		if !ok {
-			continue
-		}
-		cur := v
-	walk:
-		for _, k := range path {
-			switch cur.(type) {
-			case []any, map[string]any:
-				addr := reflect.ValueOf(cur).Pointer()
-				if _, ok := seen[addr]; !ok {
-					seen[addr] = struct{}{}
-					total += allocSize(cur)
-				}
-			default:
-				break walk
-			}
-			cur = funcIndex2(nil, cur, k)
-			if _, isErr := cur.(error); isErr {
-				break walk
-			}
-		}
-	}
-	return total
-}
-
-// deepMergeSize is the byte size of the fresh maps that map * map ( deepmerge )
-// builds. deepMergeObjectsLimited recurses only where both sides hold a map, so
-// it copies a spine of new maps and shares the rest by reference; charging the
-// whole result would over-count the shared branches, and charging only the top
-// misses the recursion, so collecting many deep merges allocated GB. This walks
-// the same overlap the merge does, so it charges exactly the new maps. It is
-// bounded because the merge already refused ( via its own size counter ) any
-// result larger than MaxAlloc, and it returns 0 for non-map operands ( ordinary
-// numeric / string multiply, charged by allocSize as before ).
-//
-// The merged map holds the UNION of the two key sets ( len(lm) plus the keys
-// only in rm ), so it is charged as such. Charging len(lm)+len(rm) double-counted
-// the shared keys and falsely rejected a large merge whose sides overlap heavily
-// ( a 55k-key self-merge, ~2.5 MB, was rejected at a 4 MiB limit ).
-func deepMergeSize(l, r any, depth int) int64 {
-	if depth > maxRecursionDepth {
-		return 0
-	}
-	lm, lok := l.(map[string]any)
-	rm, rok := r.(map[string]any)
-	if !lok || !rok {
-		return 0
-	}
-	n := int64(len(lm))*40 + 320
-	for k, rv := range rm {
-		lv, inL := lm[k]
-		if !inL {
-			n += 40 // a key only in rm adds one entry to the merged map
-			continue
-		}
-		if lvm, ok := lv.(map[string]any); ok {
-			if rvm, ok := rv.(map[string]any); ok {
-				n += deepMergeSize(lvm, rvm, depth+1)
-			}
-		}
-	}
-	return n
 }
 
 // chargeBytes adds n to the running total and reports whether the limit has
@@ -270,6 +194,24 @@ func arrayTooLarge(n int) bool {
 	return MaxAlloc > 0 && int64(n)*16 > MaxAlloc
 }
 
+// arrayAppendTooLarge reports whether growing a []any to n elements can exceed
+// MaxAlloc while append temporarily retains both its old and new backing arrays.
+// For large slices Go grows capacity by about 25%, so the old n-slot backing
+// array and new ~1.25n-slot array need about 36 bytes per eventual element at
+// the growth point. Single-shot makes use arrayTooLarge because they do not have
+// an old backing array.
+func arrayAppendTooLarge(n int) bool {
+	return MaxAlloc > 0 && int64(n) > MaxAlloc/36
+}
+
+// implodeWorkingSetTooLarge bounds the live input array plus the old and new
+// UTF-8 builder buffers that can coexist while encoding up to four bytes per
+// rune. The same conservative 36-byte factor also includes slice/buffer growth
+// slack that is not visible in the retained result size.
+func implodeWorkingSetTooLarge(n int) bool {
+	return MaxAlloc > 0 && int64(n) > MaxAlloc/36
+}
+
 // overStackLimit reports whether the interpreter's own live stacks exceed
 // MaxAlloc. Deep or infinite recursion, such as `def f: [f]; f`, grows these
 // stacks without ever completing a value, so the value meter never charges it.
@@ -278,9 +220,9 @@ func arrayTooLarge(n int) bool {
 func (env *env) overStackLimit() bool {
 	return int64(len(env.stack.data))*24+
 		int64(len(env.paths.data))*24+
-		int64(len(env.scopes.data))*48+
+		int64(len(env.scopes.data))*56+
 		int64(len(env.values))*16+
-		int64(len(env.forks))*72 > MaxAlloc
+		int64(len(env.forks))*80 > MaxAlloc
 }
 
 // decodeJSONLimited decodes one JSON value from dec, tracking the cumulative

--- a/memlimit_test.go
+++ b/memlimit_test.go
@@ -1,0 +1,1934 @@
+package gojq
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// with MaxAlloc set, a memory bomb must error instead of allocating unboundedly.
+func TestMaxAllocStopsBombs(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20 // 4 MiB
+
+	for _, src := range []string{
+		`"x" * 2000000000`,                      // string repeat
+		`"xx"` + strings.Repeat(" | . + .", 30), // doubling chain
+		`[range(100000000)]`,                    // huge array
+		`null | setpath([50000000]; 1)`,         // huge sparse array
+		`reduce range(60) as $i ("xx"; . + .)`,  // growing reduce
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		iter, gotErr := code.Run(nil), false
+		for i := 0; i < 1000000; i++ {
+			v, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if _, ok := v.(error); ok {
+				gotErr = true
+				break
+			}
+		}
+		if !gotErr {
+			t.Errorf("expected an allocation error for %q", src)
+		}
+	}
+}
+
+// with MaxAlloc set, ordinary expressions must still succeed.
+func TestMaxAllocAllowsNormal(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{`"ab" * 3`, `[range(100)] | add`, `{a: 1, b: 2}`, `. + 1`} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(3).Next()
+		if !ok {
+			t.Errorf("%q: no result", src)
+		} else if e, ok := v.(error); ok {
+			t.Errorf("%q: unexpected error: %s", src, e)
+		}
+	}
+}
+
+// each of these builtins used to build an input-proportional value in one make()
+// before the value meter could charge it. with MaxAlloc set they must now error.
+func TestMaxAllocStopsSingleShotBuiltins(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 1 << 20 // 1 MiB
+
+	bigStr := strings.Repeat("a", 1<<20)
+	bigArr := make([]any, 1<<20)
+	for i := range bigArr {
+		bigArr[i] = float64(i)
+	}
+	for _, c := range []struct {
+		src string
+		in  any
+	}{
+		{`explode`, bigStr},   // string -> []any (x16)
+		{`. / ""`, bigStr},    // split operator on empty separator
+		{`split("")`, bigStr}, // split builtin
+		{`reverse`, bigArr},   // input-sized array copy
+		{`sort`, bigArr},      // sortItems make
+		{`unique`, bigArr},    // via sort
+	} {
+		query, err := Parse(c.src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", c.src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", c.src, err)
+		}
+		v, ok := code.Run(c.in).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", c.src)
+		} else if _, isErr := v.(error); !isErr {
+			t.Errorf("%q: expected an allocation error, got a value", c.src)
+		}
+	}
+}
+
+// deep or infinite recursion grows the interpreter's own stacks (operands,
+// forks, scopes) without ever completing a value, so the value meter never
+// charges it. and a big.Int can grow past the value meter because its size is
+// not the size of the interface that holds it. both must error under MaxAlloc.
+func TestMaxAllocStopsRecursionAndBigint(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	squareChain := "."
+	for i := 0; i < 30; i++ {
+		squareChain += " | (. * .)"
+	}
+	for _, c := range []struct {
+		src string
+		in  any
+	}{
+		{`def f: [f]; f`, nil}, // infinite nesting recursion
+		{squareChain, 3},       // big.Int doubling by repeated squaring
+	} {
+		query, err := Parse(c.src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", c.src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", c.src, err)
+		}
+		v, ok := code.Run(c.in).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", c.src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q: expected *allocLimitError, got %v", c.src, v)
+		}
+	}
+}
+
+// a value in a []any slot costs 16 bytes for the slot plus its own footprint,
+// so an array of a million one-character strings is ~33 MB, not the ~1 MB its
+// contents suggest. before charging the slot, such an array grew far past the
+// limit (and `add` then churned 150+ MB the meter never saw). it must now error.
+func TestMaxAllocCountsArraySlots(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`[range(1000000) | tostring]`,       // a million tiny strings
+		`[range(1000000) | tostring] | add`, // ... then concatenated
+		`[range(1000000)]`,                  // a million boxed numbers
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(nil).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isErr := v.(error); !isErr {
+			t.Errorf("%q: expected an allocation error, got a value", src)
+		}
+	}
+}
+
+// fromjson builds a whole structure from one json.Decode; a 2 MB array string
+// of a million ones would materialize ~16 MB before the value meter saw it.
+// the charging streaming decoder must stop it during the parse.
+func TestMaxAllocStopsFromJSON(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	src := "[" + strings.Repeat("1,", 999999) + "1]"
+	query, err := Parse(`fromjson`)
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatalf("Compile: %s", err)
+	}
+	v, ok := code.Run(src).Next()
+	if !ok {
+		t.Fatal("expected an error, got no result")
+	}
+	if _, isAlloc := v.(*allocLimitError); !isAlloc {
+		t.Errorf("expected *allocLimitError, got %v", v)
+	}
+}
+
+// a recursive function that binds many variables or takes many arguments grows
+// the interpreter's value-slot slice (env.values) far faster than its scope
+// stack, so the slot slice must be part of the live stack limit too.
+func TestMaxAllocStopsValueSlotGrowth(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	var binds strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&binds, ". as $a%d | ", i)
+	}
+	for _, src := range []string{
+		"def f: " + binds.String() + "[f]; f",                                    // many bindings per level
+		"def f($a;$b;$c;$d;$e;$f;$g;$h): f(.;.;.;.;.;.;.;.); f(.;.;.;.;.;.;.;.)", // many args
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse: %s", err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile: %s", err)
+		}
+		v, ok := code.Run("x").Next()
+		if !ok {
+			t.Errorf("expected an error, got no result")
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("expected *allocLimitError, got %v", v)
+		}
+	}
+}
+
+// compileRegexp caches every distinct pattern; a run generating millions of
+// them once grew the cache to 70-95 MB (and it persisted after the run). the
+// cache must stop retaining once it reaches MaxAlloc, while patterns still work.
+func TestRegexpCacheBounded(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 1 << 20 // 1 MiB
+
+	var cache reCache
+	for i := 0; i < 50000; i++ {
+		if _, err := compileRegexp(fmt.Sprintf("distinct-pattern-%d", i), "", &cache); err != nil {
+			t.Fatalf("compile %d: %s", i, err)
+		}
+	}
+	if got := cache.bytes.Load(); got > MaxAlloc+4096 {
+		t.Errorf("cache retained %d bytes for 50000 patterns, want bounded near MaxAlloc (%d)", got, int64(MaxAlloc))
+	}
+	// still correct after the cache filled: a pattern compiles and matches.
+	r, err := compileRegexp("^abc$", "", &cache)
+	if err != nil || !r.MatchString("abc") || r.MatchString("xyz") {
+		t.Errorf("regex broken after cache filled: r=%v err=%v", r, err)
+	}
+}
+
+// match with the "g" flag builds one map per match (plus one per capture group)
+// in a single make, and the result array is charged only shallowly, so a global
+// match on a moderate string materialized tens of MB under the limit. it must
+// now error, while a small match still returns correct results.
+func TestMaxAllocBoundsGlobalMatch(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := strings.Repeat("ab", 500000)
+	query, err := Parse(`[match("(a)(b)"; "g")] | length`)
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatalf("Compile: %s", err)
+	}
+	v, ok := code.Run(big).Next()
+	if !ok {
+		t.Fatal("expected an error, got no result")
+	}
+	if _, isAlloc := v.(*allocLimitError); !isAlloc {
+		t.Errorf("expected *allocLimitError for a huge global match, got %v", v)
+	}
+
+	// a small match must still return its results under the same limit.
+	query2, _ := Parse(`[match("a"; "g") | .offset]`)
+	code2, _ := Compile(query2)
+	v2, ok := code2.Run("banana").Next()
+	if !ok {
+		t.Fatal("no result for small match")
+	}
+	if got, isArr := v2.([]any); !isArr || len(got) != 3 {
+		t.Errorf("small match: expected 3 offsets, got %v", v2)
+	}
+}
+
+// the gas meter must not count transient scalars: a streaming query that
+// produces millions of numbers but holds one accumulator (a counting reduce)
+// would otherwise trip the limit though it holds almost nothing live. it must
+// complete with the right value, while collecting the same range still errors.
+func TestMaxAllocAllowsStreaming(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	query, err := Parse(`reduce range(2000000) as $x (0; . + 1)`)
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatalf("Compile: %s", err)
+	}
+	v, ok := code.Run(nil).Next()
+	if !ok {
+		t.Fatal("counting reduce: no result")
+	}
+	if e, isErr := v.(error); isErr {
+		t.Fatalf("counting reduce should complete, got error: %s", e)
+	}
+	if got := fmt.Sprint(v); got != "2000000" {
+		t.Errorf("counting reduce: got %v, want 2000000", v)
+	}
+
+	// collecting the same range into an array retains it, so it must still error.
+	q2, _ := Parse(`[range(2000000)] | length`)
+	c2, _ := Compile(q2)
+	v2, _ := c2.Run(nil).Next()
+	if _, isAlloc := v2.(*allocLimitError); !isAlloc {
+		t.Errorf("collecting 2M elements should error, got %v", v2)
+	}
+}
+
+// fromjson yields json.Number values, a distinct type from string. allocSize and
+// the streaming decoder must size them by their digit length, or a JSON document
+// of a few huge numbers slips through the parse bound (each number charged as a
+// 16-byte scalar) and downstream ops run on tens of MB of unmetered data.
+func TestMaxAllocSizesJSONNumbers(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	var b strings.Builder
+	b.WriteString("[")
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(strings.Repeat("9", 500000)) // a 500,000-digit number
+	}
+	b.WriteString("]")
+
+	query, err := Parse(`fromjson | add | tostring`)
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatalf("Compile: %s", err)
+	}
+	v, ok := code.Run(b.String()).Next()
+	if !ok {
+		t.Fatal("expected an error, got no result")
+	}
+	if _, isAlloc := v.(*allocLimitError); !isAlloc {
+		t.Errorf("fromjson of ~15 MB of numbers should error, got %v", v)
+	}
+
+	// a small number document still decodes and sums correctly.
+	q2, _ := Parse(`fromjson | add`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run("[1,2,3,4]").Next(); !ok || fmt.Sprint(v2) != "10" {
+		t.Errorf("small fromjson: expected 10, got %v", v2)
+	}
+}
+
+// index/indices/rindex on a string explode the whole haystack to a []any of
+// runes (x16); on a big string that materialized tens of MB the meter never saw
+// because the result is one number. indices on an array builds its result via an
+// internal append. both must be bounded, while small inputs still work.
+func TestMaxAllocBoundsIndex(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	bigStr := strings.Repeat("hello world ", 400000) // ~4.8 MB -> ~76 MB of runes
+	for _, src := range []string{`index("world")`, `indices("o")`, `rindex("d")`} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(bigStr).Next()
+		if !ok {
+			t.Errorf("%q: no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q on a big string: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	all := make([]any, 1000000)
+	for i := range all {
+		all[i] = float64(5)
+	}
+	query, _ := Parse(`indices(5)`)
+	code, _ := Compile(query)
+	if v, _ := code.Run(all).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+		t.Errorf("indices on an all-matches array: expected an allocation error, got a value")
+	}
+
+	q2, _ := Parse(`index("world")`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run("hello world").Next(); !ok || fmt.Sprint(v2) != "6" {
+		t.Errorf("small index: expected 6, got %v", v2)
+	}
+}
+
+// shared references (`[., .]` repeated) make a value whose own footprint is tiny
+// expand to an exponentially larger JSON encoding. tojson / tostring / @json
+// build the whole string before the meter, which only sees the result, can
+// charge it, so a tiny expression produced gigabytes. the encoder must bound it.
+func TestMaxAllocBoundsEncoding(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`reduce range(30) as $i (0; [., .]) | tojson`, // O(30) DAG, 2^30 expansion
+		`reduce range(30) as $i (0; [., .]) | tostring`,
+		`reduce range(25) as $i ({}; {a: ., b: .}) | tojson`,
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(nil).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q: expected an allocation error, got a value", src)
+		}
+	}
+
+	// ordinary encoding still works.
+	q2, _ := Parse(`tojson`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run([]any{1.0, "x", nil}).Next(); !ok || fmt.Sprint(v2) != `[1,"x",null]` {
+		t.Errorf(`tojson: expected [1,"x",null], got %v`, v2)
+	}
+}
+
+// A single string whose escaped form is far larger than the string itself
+// (each control byte becomes \u00XX, six bytes) amplifies inside encodeString,
+// which escapes the whole string in one uninterrupted loop. The between-values
+// guard in encode never fires mid-string, so tojson / @json built the entire
+// escaped blob (a 2 MB input reaching ~12 MB, peaking far higher through buffer
+// doubling) before the value meter, seeing only the finished string, could
+// charge it. The guard inside encodeString stops the escape past MaxAlloc.
+func TestMaxAllocBoundsStringEscaping(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// 2 MB of control bytes: the input is under the limit, its escaping is not.
+	ctrl := strings.Repeat(string(rune(1)), 2<<20)
+	for _, src := range []string{`tojson`, `@json`} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(ctrl).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// a clean string under the limit still encodes: no escapes, guard never trips.
+	q2, _ := Parse(`tojson`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(strings.Repeat("x", 1<<20)).Next(); !ok {
+		t.Errorf("clean string: expected a result, got none")
+	} else if _, isAlloc := v2.(*allocLimitError); isAlloc {
+		t.Errorf("clean string under the limit should encode, got alloc error")
+	}
+}
+
+// add accumulates the whole sum internally (a strings.Builder for strings, an
+// append for arrays, a merge for maps) and is charged only at the end, so on a
+// large input it built 1+ GB before the meter fired. bound the accumulation.
+func TestMaxAllocBoundsAdd(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	bigStr := strings.Repeat("a", 200000)
+	sharedStrs := make([]any, 2000)
+	for i := range sharedStrs {
+		sharedStrs[i] = bigStr
+	}
+	bigArr := make([]any, 50000)
+	for i := range bigArr {
+		bigArr[i] = float64(i)
+	}
+	sharedArrs := make([]any, 2000)
+	for i := range sharedArrs {
+		sharedArrs[i] = bigArr
+	}
+	for _, in := range []any{sharedStrs, sharedArrs} {
+		query, _ := Parse(`add | length`)
+		code, _ := Compile(query)
+		if v, _ := code.Run(in).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+			t.Errorf("add of a large shared-reference input: expected an allocation error, got a value")
+		}
+	}
+
+	// small add still returns the right values.
+	for _, c := range []struct {
+		src, in, want string
+	}{
+		{`add`, `[1,2,3,4]`, "10"},
+		{`add`, `["a","b","c"]`, "abc"},
+	} {
+		q, _ := Parse(c.src)
+		code, _ := Compile(q)
+		var iv any
+		jq, _ := Parse(c.in)
+		jc, _ := Compile(jq)
+		iv, _ = jc.Run(nil).Next()
+		if v, ok := code.Run(iv).Next(); !ok || fmt.Sprint(v) != c.want {
+			t.Errorf("add %s: expected %s, got %v", c.in, c.want, v)
+		}
+	}
+}
+
+// flatten builds its flat result with an internal append; keys / to_entries make
+// an array of the input length. all are charged only at the end, so on a large
+// input flatten alone hit 5.8 GB. they must error while small inputs still work.
+func TestMaxAllocBoundsFlattenKeys(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	nested := make([]any, 20)
+	for i := range nested {
+		inner := make([]any, 20000)
+		for j := range inner {
+			inner[j] = float64(j)
+		}
+		nested[i] = inner
+	}
+	bigObj := map[string]any{}
+	for i := 0; i < 400000; i++ {
+		bigObj[fmt.Sprintf("k%d", i)] = float64(i)
+	}
+	for _, c := range []struct {
+		src string
+		in  any
+	}{
+		{`flatten`, nested},
+		{`keys`, bigObj},
+		{`to_entries`, bigObj},
+	} {
+		query, _ := Parse(c.src)
+		code, _ := Compile(query)
+		if v, _ := code.Run(c.in).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+			t.Errorf("%q on a large input: expected an allocation error, got a value", c.src)
+		}
+	}
+
+	q, _ := Parse(`flatten`)
+	code, _ := Compile(q)
+	if v, ok := code.Run([]any{[]any{1.0, 2.0}, []any{3.0}}).Next(); !ok || fmt.Sprint(v) != "[1 2 3]" {
+		t.Errorf("flatten: expected [1 2 3], got %v", v)
+	}
+}
+
+// .[] (opiter) builds a []pathValue of the input length to iterate, unmetered,
+// so `.[] | select(false)` on a big map completed blind at 167 MB. transpose
+// makes input-sized arrays. both must be bounded, iteration still correct.
+func TestMaxAllocBoundsIterTranspose(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	bigMap := map[string]any{}
+	for i := 0; i < 300000; i++ {
+		bigMap[fmt.Sprintf("k%d", i)] = float64(i)
+	}
+	bigArr := make([]any, 300000)
+	for i := range bigArr {
+		bigArr[i] = float64(i)
+	}
+	row := func() []any {
+		r := make([]any, 300000)
+		for j := range r {
+			r[j] = float64(j)
+		}
+		return r
+	}
+	matrix := []any{row(), row()}
+	for _, c := range []struct {
+		src string
+		in  any
+	}{
+		{`.[] | select(false)`, bigMap}, // was 167 MB, meter blind
+		{`.[] | select(false)`, bigArr},
+		{`transpose`, matrix},
+	} {
+		query, _ := Parse(c.src)
+		code, _ := Compile(query)
+		v, ok := code.Run(c.in).Next()
+		if !ok {
+			t.Errorf("%q on a large input: expected an error, completed with no result", c.src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q on a large input: expected an allocation error, got %v", c.src, v)
+		}
+	}
+
+	// small iteration and transpose still correct.
+	q, _ := Parse(`[.[]]`)
+	code, _ := Compile(q)
+	if v, ok := code.Run(map[string]any{"b": 2.0, "a": 1.0}).Next(); !ok || fmt.Sprint(v) != "[1 2]" {
+		t.Errorf("[.[]] on object: expected [1 2], got %v", v)
+	}
+	q2, _ := Parse(`transpose`)
+	c2, _ := Compile(q2)
+	if v, ok := c2.Run([]any{[]any{1.0, 2.0}, []any{3.0, 4.0}}).Next(); !ok || fmt.Sprint(v) != "[[1 3] [2 4]]" {
+		t.Errorf("transpose: expected [[1 3] [2 4]], got %v", v)
+	}
+}
+
+// object/array merge operators (. + . shallow, . * . deep) build the merged
+// result internally before the opcall charges it; on a big input object they hit
+// 160 MB. the flat makes and deepMergeObjects (recursive) must be bounded.
+func TestMaxAllocBoundsMerge(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := map[string]any{}
+	for i := 0; i < 1000000; i++ {
+		big[fmt.Sprint(i)] = float64(i)
+	}
+	deep := any(map[string]any{"v": 0.0})
+	for i := 0; i < 300000; i++ {
+		deep = map[string]any{"a": deep}
+	}
+	for _, c := range []struct {
+		src string
+		in  any
+	}{
+		{`. + .`, big},          // shallow object merge
+		{`. * .`, big},          // deep object merge, wide
+		{`. * {"new": 1}`, big}, // deep merge copies the big object
+		{`. * .`, deep},         // deep merge, deep
+	} {
+		query, _ := Parse(c.src)
+		code, _ := Compile(query)
+		if v, _ := code.Run(c.in).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+			t.Errorf("%q on a big object: expected an allocation error, got a value", c.src)
+		}
+	}
+
+	// small merges still correct.
+	for _, c := range []struct{ src, in, want string }{
+		{`. + {"b": 2}`, `{"a": 1}`, "map[a:1 b:2]"},
+		{`. * {"a": {"y": 2}}`, `{"a": {"x": 1}}`, "map[a:map[x:1 y:2]]"},
+	} {
+		q, _ := Parse(c.src)
+		code, _ := Compile(q)
+		var iv any
+		jq, _ := Parse(c.in)
+		jc, _ := Compile(jq)
+		iv, _ = jc.Run(nil).Next()
+		if v, ok := code.Run(iv).Next(); !ok || fmt.Sprint(v) != c.want {
+			t.Errorf("%q: expected %s, got %v", c.src, c.want, v)
+		}
+	}
+}
+
+// array subtraction (. - r) pre-allocates a result with cap len(l); on a big
+// input array that upfront allocation must be bounded.
+func TestMaxAllocBoundsSubtract(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := make([]any, 2000000)
+	for i := range big {
+		big[i] = float64(i)
+	}
+	query, _ := Parse(`. - [1]`)
+	code, _ := Compile(query)
+	if v, _ := code.Run(big).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+		t.Errorf("array subtract on a big input: expected an allocation error, got a value")
+	}
+
+	// small subtraction still correct.
+	q, _ := Parse(`. - [2, 3]`)
+	c, _ := Compile(q)
+	if v, ok := c.Run([]any{1.0, 2.0, 3.0, 4.0}).Next(); !ok || fmt.Sprint(v) != "[1 4]" {
+		t.Errorf("subtract: expected [1 4], got %v", v)
+	}
+}
+
+// @csv/@tsv/@sh build a []string of the whole row width (formatJoin) before the
+// opcall charges the joined result; on a big row array that make is unbounded.
+func TestMaxAllocBoundsFormatJoin(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	row := make([]any, 2000000)
+	for i := range row {
+		row[i] = float64(i)
+	}
+	for _, src := range []string{`@csv`, `@tsv`, `@sh`} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, _ := code.Run(row).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+			t.Errorf("%s on a big row: expected an allocation error, got a value", src)
+		}
+	}
+
+	// small rows still format correctly.
+	q, _ := Parse(`@csv`)
+	code, _ := Compile(q)
+	if v, ok := code.Run([]any{1.0, "a,b", true, nil}).Next(); !ok || fmt.Sprint(v) != `1,"a,b",true,` {
+		t.Errorf("@csv: got %v", v)
+	}
+}
+
+// @csv / @tsv / @sh escape each string field ( a " becomes "" for csv , a '
+// becomes the four bytes \'\\'\' for sh ) through a strings.Replacer that built
+// the whole escaped field in one pass. A single quote-heavy field whose escaping
+// is several times its own size therefore materialized fully before the value
+// meter, seeing only the finished row, could charge it: a 4 MB field reached tens
+// of MB and scaled linearly with input ( a 40 MB field peaked near 230 MB ), all
+// under a 4 MB limit. boundedReplace escapes in chunks and stops past MaxAlloc.
+func TestMaxAllocBoundsFormatFieldEscaping(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// a single field whose escaped form is far larger than the field itself.
+	for _, tc := range []struct {
+		src string
+		in  any
+	}{
+		{`@csv`, []any{strings.Repeat(string(rune(34)), 3<<20)}}, // 3 MB of " -> ~6 MB
+		{`@sh`, []any{strings.Repeat("'", 3<<20)}},               // 3 MB of ' -> ~12 MB
+	} {
+		query, _ := Parse(tc.src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(tc.in).Next(); !ok {
+			t.Errorf("%s: expected an error, got no result", tc.src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%s on a huge quote-heavy field: expected an allocation error, got %v", tc.src, v)
+		}
+	}
+
+	// a clean field under the limit must still format: escaping does not expand it,
+	// so the chunked check never trips ( no false positive on large clean content ).
+	q, _ := Parse(`@csv`)
+	code, _ := Compile(q)
+	if v, ok := code.Run([]any{strings.Repeat("x", 2<<20)}).Next(); !ok {
+		t.Errorf("clean field: expected a result, got none")
+	} else if _, isAlloc := v.(*allocLimitError); isAlloc {
+		t.Errorf("clean 2 MB field under the limit should format, got alloc error")
+	}
+}
+
+// @html / @uri / @base64 each built the whole escaped or encoded output in one
+// pass ( htmlEscaper.Replace up to 6x for ' -> &apos; , url.QueryEscape up to 3x,
+// base64 4/3x ) with no in-loop bound, so a big input scaled the peak linearly
+// ( @html on 40 MB reached ~460 MB ) under a 4 MB limit. @html/@uri now escape in
+// chunks ( boundedReplace ) ; @base64 pre-checks its deterministic encoded length.
+func TestMaxAllocBoundsFormatEscapers(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, tc := range []struct {
+		src string
+		in  string
+	}{
+		{`@html`, strings.Repeat("'", 3<<20)},             // ' -> &apos; (6x)
+		{`@uri`, strings.Repeat(string(rune(34)), 3<<20)}, // " -> %22 (3x)
+		{`@base64`, strings.Repeat("A", 4<<20)},           // 4/3x, over the limit
+	} {
+		query, _ := Parse(tc.src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(tc.in).Next(); !ok {
+			t.Errorf("%s: expected an error, got no result", tc.src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%s on a huge input: expected an allocation error, got %v", tc.src, v)
+		}
+	}
+
+	// benign inputs still produce the exact escaping/encoding.
+	for _, tc := range []struct{ src, in, want string }{
+		{`@html`, "a<b>&'x", "a&lt;b&gt;&amp;&apos;x"},
+		{`@uri`, "a b/c", "a%20b%2Fc"},
+		{`@base64`, "hello", "aGVsbG8="},
+	} {
+		query, _ := Parse(tc.src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(tc.in).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%s: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+
+	// a clean large field does not expand, so it must still format ( no false positive ).
+	q, _ := Parse(`@html`)
+	code, _ := Compile(q)
+	if v, ok := code.Run(strings.Repeat("x", 3<<20)).Next(); !ok {
+		t.Errorf("clean @html: expected a result")
+	} else if _, isAlloc := v.(*allocLimitError); isAlloc {
+		t.Errorf("clean 3 MB @html should format, got alloc error")
+	}
+}
+
+// implode builds a string from a codepoint array through a strings.Builder that
+// is bounded per rune, but sb.Grow(len(vs)) pre-allocated len(vs) bytes upfront,
+// so a huge input array forced that allocation before the per-rune check could
+// fire ( a 60M-element array reserved 60 MB under a 4 MB limit ). The Grow is now
+// capped at MaxAlloc; the per-rune check still bounds the actual writes.
+func TestMaxAllocBoundsImplode(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// 2M four-byte codepoints -> an ~8 MB string, over the limit.
+	big := make([]any, 2000000)
+	for i := range big {
+		big[i] = float64(0x10000)
+	}
+	query, _ := Parse(`implode`)
+	code, _ := Compile(query)
+	if v, _ := code.Run(big).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+		t.Errorf("implode on a huge codepoint array: expected an allocation error, got a value")
+	}
+
+	// a small implode still produces the exact string.
+	if v, ok := code.Run([]any{float64(104), float64(105)}).Next(); !ok || fmt.Sprint(v) != "hi" {
+		t.Errorf(`implode: got %v, want hi`, v)
+	}
+}
+
+// setpath builds the spine of nested containers toward the target, one
+// makeArray / makeObject per path element. A path of increasing indices
+// [0,1,...,N-1] pads the array at each depth to its index, so the whole structure
+// holds 1+2+...+N = N^2/2 slots while every single array stays small ( never
+// tripping the per-array guard ) and the shallow return-charge counts only the top
+// level. setpath([range(3000)];1) completed at 74 MB and [range(8000)] at 514 MB
+// under a 4 MB limit. A cumulative counter threaded through update now bounds the
+// whole spine build.
+func TestMaxAllocBoundsSetpathPadding(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`setpath([range(8000)]; 1)`,    // quadratic array padding, many small arrays
+		`setpath([200000, 200000]; 1)`, // two arrays each under the limit, cumulatively over
+	} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		// setpath wraps the allocLimitError, so match the message not the type.
+		if v, ok := code.Run(nil).Next(); !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if !strings.Contains(fmt.Sprint(v), "allocation exceeds") {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// benign setpath / assignment still build the exact structure.
+	for _, tc := range []struct{ src, want string }{
+		{`setpath(["a", "b"]; 5)`, `{"a":{"b":5}}`},
+		{`[1, 2, 3, 4] | setpath([2]; 9)`, `[1,2,9,4]`},
+		{`{} | .a.b.c = 7`, `{"a":{"b":{"c":7}}}`},
+		{`[1, 2, 3] | del(.[1])`, `[1,3]`},
+	} {
+		query, _ := Parse(tc.src + " | tojson")
+		code, _ := Compile(query)
+		if v, ok := code.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// strftime / strflocaltime format a time with a format string taken as an
+// argument, which can come from input ( strftime(.field) ). timefmt.Format builds
+// the whole result in one pass and directives such as %A / %B / %c expand a
+// two-byte directive to many bytes, so a big input format amplified the output far
+// past the limit ( a 40 MB format of %A reached 358 MB ) before the value meter,
+// seeing only the finished string, could charge it. A format-length pre-check now
+// rejects a format whose worst-case expansion could exceed MaxAlloc.
+func TestMaxAllocBoundsStrftime(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	bigfmt := strings.Repeat("%A", 2<<20) // 4 MB of weekday directives
+	for _, src := range []string{
+		`. as $f | 1700000000 | gmtime | strftime($f)`,
+		`. as $f | 1700000000 | gmtime | strflocaltime($f)`,
+	} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(bigfmt).Next(); !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q on a huge format: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// realistic formats still produce the exact string.
+	q, _ := Parse(`1700000000 | gmtime | strftime("%Y-%m-%dT%H:%M:%SZ")`)
+	code, _ := Compile(q)
+	if v, ok := code.Run(nil).Next(); !ok || fmt.Sprint(v) != "2023-11-14T22:13:20Z" {
+		t.Errorf(`strftime: got %v, want 2023-11-14T22:13:20Z`, v)
+	}
+}
+
+// indices / index / rindex compared xs against vs[i:i+len(xs)] on every position,
+// which boxed a fresh slice header into Compare each step. Over a large array that
+// was tens of MB of transient garbage for even a single match ( indices(5) on a 2M
+// array peaked at 52 MB and scaled with input ), all invisible to the meter since
+// the result is tiny. matchAt now compares element by element ( no reslice, no box ).
+func TestMaxAllocBoundsIndices(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// many matches still hit the result cap.
+	big := make([]any, 2000000)
+	for i := range big {
+		big[i] = float64(1)
+	}
+	query, _ := Parse(`indices(1)`)
+	code, _ := Compile(query)
+	if v, _ := code.Run(big).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+		t.Errorf("indices with 2M matches: expected an allocation error, got a value")
+	}
+
+	// the element-wise comparison preserves exact results.
+	for _, tc := range []struct {
+		src  string
+		in   any
+		want string
+	}{
+		{`indices(2)`, []any{1.0, 2.0, 3.0, 2.0, 2.0}, `[1,3,4]`},
+		{`index(2)`, []any{1.0, 2.0, 3.0}, `1`},
+		{`rindex(2)`, []any{1.0, 2.0, 3.0, 2.0}, `3`},
+		{`indices([1, 2])`, []any{0.0, 1.0, 2.0, 1.0, 2.0}, `[1,3]`},
+		{`indices("a")`, "banana", `[1,3,5]`},
+	} {
+		q, _ := Parse(tc.src + " | tojson")
+		c, _ := Compile(q)
+		if v, ok := c.Run(tc.in).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%s: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// jsonMarshal backs Error()/String() formatting and runs the encode guard, which
+// panics once the buffer passes MaxAlloc. Unlike Marshal it did not recover that
+// panic, so formatting a halt_error / error that carries a big non-string value
+// ( e.g. halt_error on a large input array ) crashed the process with an uncaught
+// panic. jsonMarshal now recovers and returns the bounded prefix.
+func TestMaxAllocErrorFormattingBounded(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := make([]any, 2000000)
+	for i := range big {
+		big[i] = float64(i)
+	}
+	for _, src := range []string{`error`, `halt_error`, `halt_error(1)`} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		v, ok := code.Run(big).Next()
+		if !ok {
+			t.Fatalf("%q: expected an error value", src)
+		}
+		err, isErr := v.(error)
+		if !isErr {
+			t.Fatalf("%q: expected an error, got %T", src, v)
+		}
+		msg := err.Error() // must not panic
+		if int64(len(msg)) > MaxAlloc+64 {
+			t.Errorf("%q: error message len %d exceeds the limit", src, len(msg))
+		}
+	}
+}
+
+// Encoding a big integer to base 10 ( tojson / tostring / @json / interpolation )
+// runs v.Append(buf, 10), which allocates large superlinear scratch inside
+// math/big: a 4 MB integer peaks past 100 MB , none of it seen by the encoder's
+// between-values guard. A ~512 KB integer builds fine ( under the limit ) yet its
+// decimal form costs ~25 MB , so serializing it is now refused.
+func TestMaxAllocBoundsBigintEncoding(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`(reduce range(22) as $x (2; . * .)) | tojson`,
+		`(reduce range(22) as $x (2; . * .)) | tostring`,
+		`(reduce range(22) as $x (2; . * .)) | @json`,
+	} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(nil).Next(); !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// ordinary numbers, including a moderately large big integer, still serialize.
+	for _, tc := range []struct{ src, want string }{
+		{`12345 | tojson`, `12345`},
+		{`(2 | . * . * .) | tojson`, `8`},
+		{`(reduce range(10) as $x (2; . * .)) | tojson | length > 0`, `true`},
+	} {
+		q, _ := Parse(tc.src)
+		c, _ := Compile(q)
+		if v, ok := c.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// bigToFloat converted a big integer to float64 via strconv.ParseFloat(x.String()),
+// and x.String() runs the same superlinear base-10 conversion as round 78: a 10 MB
+// integer divided by a small number reached ~300 MB inside math/big, unseen by the
+// meter. Division falls back to bigToFloat when not evenly divisible, and mixed
+// int/float arithmetic on a big integer goes through it too. It now converts via
+// big.Float ( binary , bounded , correctly rounded ).
+func TestMaxAllocBigToFloatBounded(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// a big integer built by squaring, divided by a small number, exercises the
+	// bigToFloat fallback and must complete without erroring or blowing up.
+	q0, _ := Parse(`(reduce range(23) as $x (2; . * .)) / 7`)
+	c0, _ := Compile(q0)
+	if v, ok := c0.Run(nil).Next(); !ok {
+		t.Errorf("big bigint / 7: expected a result")
+	} else if _, isErr := v.(error); isErr {
+		t.Errorf("big bigint / 7: unexpected error %v", v)
+	}
+
+	// the conversion stays correct: exact division yields the exact integer, and
+	// comparisons against floats give the right result.
+	for _, tc := range []struct{ src, want string }{
+		{`(reduce range(6) as $x (2; . * .)) / 4`, `4611686018427387904`}, // 2^64 / 4 = 2^62, exact
+		{`(reduce range(6) as $x (2; . * .)) < 1e20`, `true`},             // 2^64 < 1e20 via bigToFloat
+		{`(reduce range(6) as $x (2; . * .)) > 1e19`, `true`},             // 2^64 > 1e19
+	} {
+		q, _ := Parse(tc.src)
+		c, _ := Compile(q)
+		if v, ok := c.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// timefmt.Parse reads the whole input and format into runes before matching, so
+// strptime on a big input string ( which fails on extra text anyway ) allocated
+// several times its size: an 8 MB input peaked at 49 MB. A length pre-check now
+// refuses an input or format whose parse could pass MaxAlloc; real date strings
+// are tiny, so only absurd inputs are refused.
+func TestMaxAllocBoundsStrptime(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := strings.Repeat("2024", 2000000) // 8 MB
+	for _, tc := range []struct {
+		src string
+		in  any
+	}{
+		{`strptime("%Y")`, big},
+		{`. as $f | "2024" | strptime($f)`, big}, // big format
+	} {
+		query, _ := Parse(tc.src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(tc.in).Next(); !ok {
+			t.Errorf("%q: expected an error, got no result", tc.src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q on a huge input: expected an allocation error, got %v", tc.src, v)
+		}
+	}
+
+	// realistic date strings still parse correctly.
+	for _, tc := range []struct{ src, want string }{
+		{`"2024-01-15" | strptime("%Y-%m-%d") | .[0]`, `2024`},
+		{`"2024-01-15T10:30:00Z" | strptime("%Y-%m-%dT%H:%M:%SZ") | .[2]`, `15`},
+	} {
+		q, _ := Parse(tc.src)
+		c, _ := Compile(q)
+		if v, ok := c.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// encode is Go-recursive ( encode -> encodeArray -> encode ) and is NOT covered by
+// the interpreter's overStackLimit ; the buffer guard does not fire on a deep-narrow
+// value ( each level adds one byte on the way down ). A deeply nested value therefore
+// overflowed the goroutine stack in tojson / tostring / @json - a fatal, unrecoverable
+// crash, not a panic. A recursion-depth bound now refuses a value whose nesting alone
+// exceeds the limit ( >= 16 bytes per level ).
+func TestMaxAllocBoundsEncodeDepth(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	var deepArr any = 0.0
+	for i := 0; i < 500000; i++ {
+		deepArr = []any{deepArr}
+	}
+	var deepObj any = 0.0
+	for i := 0; i < 500000; i++ {
+		deepObj = map[string]any{"a": deepObj}
+	}
+	for _, tc := range []struct {
+		src string
+		in  any
+	}{
+		{`tojson`, deepArr}, {`tostring`, deepArr}, {`@json`, deepArr}, {`tojson`, deepObj},
+	} {
+		query, _ := Parse(tc.src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(tc.in).Next(); !ok {
+			t.Errorf("%s on a deep value: expected an error, got no result", tc.src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%s on a deep value: expected an allocation error, got %v", tc.src, v)
+		}
+	}
+
+	// normal nesting still encodes correctly.
+	q, _ := Parse(`tojson`)
+	code, _ := Compile(q)
+	if v, ok := code.Run([]any{[]any{1.0, []any{2.0}}, map[string]any{"a": 3.0}}).Next(); !ok || fmt.Sprint(v) != `[[1,[2]],{"a":3}]` {
+		t.Errorf("tojson of a normal value: got %v", v)
+	}
+}
+
+// Several value operations recurse in Go on the structure's nesting depth -
+// Compare ( sort / unique / min / < / == / group_by ), contains / inside, and
+// flatten - none covered by the interpreter's overStackLimit. A deeply nested
+// value overflowed the goroutine stack ( a fatal crash, not a panic ). Depth
+// bounds now make them error ; Next recovers the Compare / contains panic.
+func TestMaxAllocBoundsDeepRecursion(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	var deep any = 0.0
+	for i := 0; i < 500000; i++ {
+		deep = []any{deep}
+	}
+	for _, src := range []string{
+		`[., .] | sort`, `[., .] | unique`, `[., .] | group_by(.)`, `[., .] | min`,
+		`. < .`, `. == .`, `contains(.)`, `inside(.)`, `flatten`,
+	} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(deep).Next(); !ok {
+			t.Errorf("%q on a deep value: expected an error, got no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q on a deep value: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// normal nesting still compares and flattens correctly.
+	for _, tc := range []struct{ src, want string }{
+		{`[[3], [1], [2]] | sort | tojson`, `[[1],[2],[3]]`},
+		{`[[1, [2, [3]]]] | flatten | tojson`, `[1,2,3]`},
+		{`{"a": {"b": 1}} | contains({"a": {"b": 1}})`, `true`},
+		{`([1] < [2])`, `true`},
+	} {
+		q, _ := Parse(tc.src)
+		c, _ := Compile(q)
+		if v, ok := c.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// delpaths strips empty markers by walking the whole result recursively in Go
+// ( deleteEmpty ), so del of a shallow key on a value with a deeply nested sibling
+// overflowed the goroutine stack ( a fatal crash ). A depth bound now makes it
+// error ; the interpreter's Next recovers the panic.
+func TestMaxAllocBoundsDeleteEmpty(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	var deep any = 0.0
+	for i := 0; i < 500000; i++ {
+		deep = []any{deep}
+	}
+	in := map[string]any{"deep": deep, "x": 1.0}
+	for _, src := range []string{`del(.x)`, `delpaths([["x"]])`} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, ok := code.Run(in).Next(); !ok {
+			t.Errorf("%q with a deep sibling: expected an error, got no result", src)
+		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
+			t.Errorf("%q with a deep sibling: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// normal del still works.
+	q, _ := Parse(`del(.b) | tojson`)
+	code, _ := Compile(q)
+	if v, ok := code.Run(map[string]any{"a": 1.0, "b": 2.0}).Next(); !ok || fmt.Sprint(v) != `{"a":1}` {
+		t.Errorf(`del(.b): got %v`, v)
+	}
+}
+
+// update recurses once per path element and the round-69 size counters only
+// charge on the way UP, so a long path from input ( which is not metered )
+// overflowed the goroutine stack on the way DOWN before any charge fired. The
+// path length is the recursion depth, so it is now pre-checked at the top of
+// update. getpath is iterative and unaffected.
+func TestMaxAllocBoundsSetpathPathLength(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// a 300k-element path ( > MaxAlloc/16 ) - the recursion would be 300k deep.
+	arrPath := make([]any, 300000)
+	for i := range arrPath {
+		arrPath[i] = float64(0)
+	}
+	objPath := make([]any, 300000)
+	for i := range objPath {
+		objPath[i] = "a"
+	}
+	for _, tc := range []struct {
+		src string
+		p   []any
+	}{
+		{`. as $p | null | setpath($p; 1)`, arrPath},
+		{`. as $p | null | setpath($p; 1)`, objPath},
+		{`. as $p | {a: {a: 1}} | delpaths([$p])`, objPath},
+	} {
+		query, _ := Parse(tc.src)
+		code, _ := Compile(query)
+		// setpath/delpaths wrap the error, so match the message.
+		if v, ok := code.Run(tc.p).Next(); !ok {
+			t.Errorf("%q with a huge path: expected an error, got no result", tc.src)
+		} else if !strings.Contains(fmt.Sprint(v), "allocation exceeds") {
+			t.Errorf("%q with a huge path: expected an allocation error, got %v", tc.src, v)
+		}
+	}
+
+	// normal-length paths still work.
+	q, _ := Parse(`null | setpath(["a", "b"]; 5) | tojson`)
+	code, _ := Compile(q)
+	if v, ok := code.Run(nil).Next(); !ok || fmt.Sprint(v) != `{"a":{"b":5}}` {
+		t.Errorf("setpath: got %v", v)
+	}
+}
+
+// add/flatten/join on a map go through values(), which makes a []any of the
+// map's size; on a big map that make is unmetered, so `add` (result is a number)
+// completed meter-blind. values() must error on a big map, keeping correctness.
+func TestMaxAllocBoundsValues(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := map[string]any{}
+	for i := 0; i < 2000000; i++ {
+		big[fmt.Sprint(i)] = float64(i)
+	}
+	for _, src := range []string{`add`, `flatten`} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, _ := code.Run(big).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+			t.Errorf("%s on a big map: expected an allocation error, got a value", src)
+		}
+	}
+
+	// small map ops still correct, and the type error is preserved.
+	q, _ := Parse(`add`)
+	code, _ := Compile(q)
+	if v, ok := code.Run(map[string]any{"a": 1.0, "b": 2.0}).Next(); !ok || fmt.Sprint(v) != "3" {
+		t.Errorf("add on small map: expected 3, got %v", v)
+	}
+	q2, _ := Parse(`add`)
+	c2, _ := Compile(q2)
+	if v, _ := c2.Run("x").Next(); func() bool { _, ok := v.(*allocLimitError); return ok }() {
+		t.Errorf("add on a string should be a type error, not an alloc error")
+	}
+}
+
+// encodeObject makes a []keyVal of the map's size to sort keys, at object entry -
+// before the encoder's output-length check (round 22) - so tojson/tostring/@json
+// of a big map spiked on it. must error, small objects still encode sorted.
+func TestMaxAllocBoundsEncodeObject(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := map[string]any{}
+	for i := 0; i < 1000000; i++ {
+		big[fmt.Sprint(i)] = float64(i)
+	}
+	query, _ := Parse(`tojson`)
+	code, _ := Compile(query)
+	if v, _ := code.Run(big).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+		t.Errorf("tojson of a big map: expected an allocation error, got a value")
+	}
+
+	q, _ := Parse(`tojson`)
+	c, _ := Compile(q)
+	if v, ok := c.Run(map[string]any{"b": 2.0, "a": 1.0}).Next(); !ok || fmt.Sprint(v) != `{"a":1,"b":2}` {
+		t.Errorf("tojson small object: got %v", v)
+	}
+}
+
+// slice assignment (.[a:b] = x) rebuilds the array via a.makeArray(~len(v));
+// on a big input array that make must be bounded. small slices still work.
+func TestMaxAllocBoundsSliceAssign(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := make([]any, 2000000)
+	for i := range big {
+		big[i] = float64(i)
+	}
+	query, _ := Parse(`.[0:1] = [9]`)
+	code, _ := Compile(query)
+	// setpath wraps the allocLimitError, so match on the message.
+	if v, _ := code.Run(big).Next(); !strings.Contains(fmt.Sprint(v), "allocation exceeds") {
+		t.Errorf("slice assign on a big array: expected an allocation error, got %v", v)
+	}
+
+	q, _ := Parse(`.[1:3] = [9, 9]`)
+	c, _ := Compile(q)
+	if v, ok := c.Run([]any{0.0, 1.0, 2.0, 3.0, 4.0}).Next(); !ok || fmt.Sprint(v) != "[0 9 9 3 4]" {
+		t.Errorf("slice assign: got %v", v)
+	}
+}
+
+// setpath/modify/del on a map copy it via a.makeObject(len(v)+1); on a big map
+// that copy is unbounded. must error (message-matched - setpath wraps it).
+func TestMaxAllocBoundsObjectUpdate(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	big := map[string]any{}
+	for i := 0; i < 1000000; i++ {
+		big[fmt.Sprint(i)] = float64(i)
+	}
+	for _, src := range []string{`.new = 1`, `del(.["500000"])`} {
+		query, _ := Parse(src)
+		code, _ := Compile(query)
+		if v, _ := code.Run(big).Next(); !strings.Contains(fmt.Sprint(v), "allocation exceeds") {
+			t.Errorf("%s on a big map: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	q, _ := Parse(`.c = 3`)
+	c, _ := Compile(q)
+	if v, ok := c.Run(map[string]any{"a": 1.0, "b": 2.0}).Next(); !ok || fmt.Sprint(v) != "map[a:1 b:2 c:3]" {
+		t.Errorf(".c=3: got %v", v)
+	}
+}
+
+// add's map path clones the first map (maps.Clone) unguarded; a caller-provided
+// array with a big map first element made add copy it (156 MB) before the merge
+// guard. must error; the first-array case was already guarded in round 25.
+func TestMaxAllocBoundsAddMapClone(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+	big := map[string]any{}
+	for i := 0; i < 2000000; i++ {
+		big[fmt.Sprint(i)] = float64(i)
+	}
+	query, _ := Parse(`add`)
+	code, _ := Compile(query)
+	if v, _ := code.Run([]any{big, map[string]any{"z": 1.0}}).Next(); func() bool { _, ok := v.(*allocLimitError); return !ok }() {
+		t.Errorf("add of [bigmap, ...]: expected an allocation error, got a value")
+	}
+	q, _ := Parse(`add`)
+	c, _ := Compile(q)
+	if v, ok := c.Run([]any{map[string]any{"a": 1.0}, map[string]any{"b": 2.0}}).Next(); !ok || fmt.Sprint(v) != "map[a:1 b:2]" {
+		t.Errorf("add of small maps: got %v", v)
+	}
+}
+
+// A memory-limit error can be caught by try/catch, //, or ?, but the meter is
+// monotonic: catching it does not reset env.alloc, so a further allocation
+// after the catch still fails. This is what stops a suppress-and-retry loop
+// from defeating the limit by swallowing each error and allocating again.
+func TestMaxAllocMonotonicAcrossCatch(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`try [range(1000000)] catch "caught" | [range(1000000)] | length`,
+		`(([range(1000000)] | length) // 999) | . + ([range(1000000)] | length)`,
+		`reduce range(1000) as $_ (0; . + (([range(1000000)] | length)? // 0))`,
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("%q: parse: %v", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("%q: compile: %v", src, err)
+		}
+		v, ok := code.Run(nil).Next()
+		if !ok {
+			t.Errorf("%q: expected a result", src)
+			continue
+		}
+		if _, isErr := v.(error); !isErr {
+			t.Errorf("%q: expected the limit to hold after the catch, got %v", src, v)
+		}
+	}
+}
+
+// The encoder is not the only thing that materializes a shared-reference DAG.
+// walk, flatten, tostream, and recurse ( .. ) each rebuild or enumerate every
+// logical node, so a tiny O(K) DAG with 2^K logical nodes expands under them
+// as well. Each must charge as it expands and stop at the limit, the same way
+// tojson does ( see TestMaxAllocBoundsEncoding ), not run on to OOM.
+func TestMaxAllocBoundsDAGTraversal(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	objDAG := `reduce range(35) as $_ (1; {a: ., b: .})`
+	arrDAG := `reduce range(35) as $_ ([1]; [., .])`
+	for _, src := range []string{
+		objDAG + ` | walk(.)`,
+		objDAG + ` | [tostream]`,
+		objDAG + ` | [..]`,
+		arrDAG + ` | flatten`,
+		arrDAG + ` | walk(.)`,
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(nil).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isErr := v.(error); !isErr || !strings.Contains(fmt.Sprint(v), "allocation exceeds") {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// the same traversals still work on an ordinary small value.
+	q2, _ := Parse(`walk(if type == "number" then . + 1 else . end)`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run([]any{1.0, 2.0}).Next(); !ok || fmt.Sprint(v2) != "[2 3]" {
+		t.Errorf("walk on small value: got %v", v2)
+	}
+}
+
+// Each run must be independently bounded: env.alloc lives on the per-run env
+// created by newEnv, not on a shared global, and no run mutates state another
+// run can see. Run a memory bomb and a legit query concurrently on shared
+// compiled code and assert every bomb errors and every legit run returns its
+// own correct answer. Under `go test -race` this also guards against a data
+// race on the per-Code regex cache or the package builtin tables.
+func TestMaxAllocConcurrentRunsIsolated(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	bombQ, err := Parse(`[range(100000000)]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bomb, err := Compile(bombQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legitQ, err := Parse(`.a + .b`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legit, err := Compile(legitQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 32
+	var wg sync.WaitGroup
+	bombErrored := make([]bool, n)
+	legitCorrect := make([]bool, n)
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			iter := bomb.Run(nil)
+			for {
+				v, ok := iter.Next()
+				if !ok {
+					break
+				}
+				if _, isErr := v.(error); isErr {
+					bombErrored[i] = true
+					break
+				}
+			}
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			if v, ok := legit.Run(map[string]any{"a": float64(i), "b": 1.0}).Next(); ok {
+				if r, isNum := v.(float64); isNum && r == float64(i)+1 {
+					legitCorrect[i] = true
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if !bombErrored[i] {
+			t.Errorf("run %d: bomb did not error under concurrency", i)
+		}
+		if !legitCorrect[i] {
+			t.Errorf("run %d: legit query returned a wrong or missing result under concurrency", i)
+		}
+	}
+}
+
+// Assignment ( |= ) materializes a shared-reference DAG the same way the
+// read-only traversals do ( see TestMaxAllocBoundsDAGTraversal ): de-sharing
+// each branch to update its leaves expands the 2^K logical nodes. The update
+// path also grows an allocator map that records every container it copies, but
+// that map is bounded because each entry is a charge-preceded copy and repeated
+// updates to an already-copied container reuse it in place. So the assignment
+// stops at the limit instead of growing the value or the allocator to OOM.
+func TestMaxAllocBoundsDAGAssignment(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`reduce range(25) as $_ (1; {a: ., b: .}) | (.. | numbers) |= . + 1`,
+		`reduce range(25) as $_ ([0]; [., .]) | (.. | numbers) |= . + 1`,
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		v, ok := code.Run(nil).Next()
+		if !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isErr := v.(error); !isErr || !strings.Contains(fmt.Sprint(v), "allocation exceeds") {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// an ordinary assignment still works.
+	q2, _ := Parse(`.a.b |= . + 1`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(map[string]any{"a": map[string]any{"b": 1.0}}).Next(); !ok || fmt.Sprint(v2) != "map[a:map[b:2]]" {
+		t.Errorf("assignment on small value: got %v", v2)
+	}
+}
+
+// funcMatch builds each match object's nested captures array internally, not
+// through the collect opcodes, so the shallow value meter charged only the
+// top-level match map ( ~112 bytes ) while the object holds one capture map per
+// group. A query collecting many matches, each with many capture groups,
+// allocated hundreds of MB ( a short regex reached ~950 MB ) while the meter saw
+// almost nothing. matchResultSize now charges the captures' real size.
+func TestMaxAllocBoundsMatchCaptures(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// 10000 matches, each with 50 capture groups; the captures dominate the
+	// object and must be charged, so this errors instead of building ~GB.
+	src := `("(.)" * 50) as $re | ("a" * 50) as $s | [range(10000) | ($s | match($re))] | length`
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := code.Run(nil).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected an allocation error for many capture-heavy matches, got %v", v)
+	}
+
+	// an ordinary match with capture groups still works.
+	q2, _ := Parse(`"2024-01-15" | [match("([0-9]+)-([0-9]+)-([0-9]+)").captures[].string]`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(nil).Next(); !ok || fmt.Sprint(v2) != "[2024 01 15]" {
+		t.Errorf("ordinary match: got %v", v2)
+	}
+}
+
+// fromjson decodes a fresh nested tree. decodeJSONLimited bounds a single
+// decode, but the result was otherwise charged at its top level only, so a
+// query collecting many decodes of a deeply-nested JSON string ( a ~40 KB
+// string reached ~3.7 GB ) allocated unbounded while the meter saw ~16 bytes
+// per decode. deepSize now charges the whole decoded tree at the native result.
+func TestMaxAllocBoundsFromjsonCollection(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// a deeply-nested JSON string decoded a million times and collected: each
+	// decode is tiny at the top but large nested, so this must error.
+	src := `("[" * 20000 + "0" + "]" * 20000) as $j | [range(1000000) | ($j | fromjson)] | length`
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := code.Run(nil).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected an allocation error collecting deep fromjson, got %v", v)
+	}
+
+	// ordinary fromjson still works.
+	q2, _ := Parse(`"[1,2,3]" | fromjson | add`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(nil).Next(); !ok || fmt.Sprint(v2) != "6" {
+		t.Errorf("ordinary fromjson: got %v", v2)
+	}
+}
+
+// transpose builds a fresh outer array of inner arrays whose elements are refs
+// into the input. The shallow meter charged only the outer array, so an N-by-2
+// transpose ( two wide inner arrays ) collected in a loop reached ~2.2 GB while
+// the meter saw ~48 bytes per result. transposeResultSize now charges the inner
+// arrays' slots. ( Round 120 missed this: it tested the 2-by-N orientation,
+// which is many NARROW inner arrays and stays bounded. )
+func TestMaxAllocBoundsTransposeCollection(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// N-by-2 input transposes to two N-wide inner arrays; collecting a million
+	// of them must error instead of building GB.
+	src := `([range(2000)] | map([., .])) as $m | [range(1000000) | ($m | transpose)] | length`
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := code.Run(nil).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected an allocation error collecting wide transposes, got %v", v)
+	}
+
+	// an ordinary transpose still works.
+	q2, _ := Parse(`[[1, 2, 3], [4, 5, 6]] | transpose`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(nil).Next(); !ok || fmt.Sprint(v2) != "[[1 4] [2 5] [3 6]]" {
+		t.Errorf("ordinary transpose: got %v", v2)
+	}
+}
+
+// setpath ( and |= / = ) copies a fresh spine of containers from the root down
+// to the target and shares the rest of the input by reference. The shallow
+// meter charged only the top of the result, so a deep-path setpath collected in
+// a loop ( a 1000-deep path reached ~2 GB ) allocated the spine unbounded.
+// spineSize now charges the copied spine, while leaving a shallow assignment
+// charged as before ( its spine is just the top ).
+func TestMaxAllocBoundsSetpathSpine(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`[range(1000) | 0] as $p | [range(1000000) | (null | setpath($p; 1))] | length`,
+		`[range(1000) | 0] as $p | [range(1000000) | (null | setpath($p; 1) | getpath($p) |= . + 1)] | length`,
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		if v, ok := code.Run(nil).Next(); !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isErr := v.(error); !isErr {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// ordinary setpath and deep assignment still produce the right value.
+	q2, _ := Parse(`setpath([0, 0, 0]; 5)`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(nil).Next(); !ok || fmt.Sprint(v2) != "[[[5]]]" {
+		t.Errorf("setpath: got %v", v2)
+	}
+	q3, _ := Parse(`.a.b.c = 7`)
+	c3, _ := Compile(q3)
+	in := map[string]any{"a": map[string]any{"b": map[string]any{"c": 1.0}}}
+	if v3, ok := c3.Run(in).Next(); !ok || fmt.Sprint(v3) != "map[a:map[b:map[c:7]]]" {
+		t.Errorf("assignment: got %v", v3)
+	}
+}
+
+// delpaths ( and del, and |= empty ) copies a fresh spine per deleted path via
+// the same copy-on-write as setpath, but was not in the deep-charge switch: the
+// run meter saw only the shallow top of the result, so collecting many deep-path
+// deletions of a bound value allocated the copied spines unbounded ( a 1000-deep
+// object deleted in a loop peaked ~75 MB at a 4 MiB limit ). delpathsSize now
+// charges each path's spine from the input, matching what update copies. Both
+// the native "delpaths" and the assignment "_delpaths" opcode are covered.
+func TestMaxAllocBoundsDelpathsSpine(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	for _, src := range []string{
+		`(reduce range(1000) as $i (0; {a: .})) as $x | ([range(1000) | "a"]) as $p | [range(1000000) | ($x | delpaths([$p]))] | length`,
+		`(reduce range(1500) as $i (0; {a: .})) as $x | [range(1000000) | ($x | del(.a.a.a.a.a))] | length`,
+		`(reduce range(1000) as $i (0; {a: .})) as $x | [range(1000000) | ($x | (getpath([range(999) | "a"])) |= empty)] | length`,
+	} {
+		query, err := Parse(src)
+		if err != nil {
+			t.Fatalf("Parse(%q): %s", src, err)
+		}
+		code, err := Compile(query)
+		if err != nil {
+			t.Fatalf("Compile(%q): %s", src, err)
+		}
+		if v, ok := code.Run(nil).Next(); !ok {
+			t.Errorf("%q: expected an error, got no result", src)
+		} else if _, isErr := v.(error); !isErr {
+			t.Errorf("%q: expected an allocation error, got %v", src, v)
+		}
+	}
+
+	// ordinary delpaths and del still produce the right value.
+	q4, _ := Parse(`delpaths([["a", "b"], ["c"]])`)
+	c4, _ := Compile(q4)
+	in4 := map[string]any{"a": map[string]any{"b": 1.0}, "c": 2.0, "d": 3.0}
+	if v4, ok := c4.Run(in4).Next(); !ok || fmt.Sprint(v4) != "map[a:map[] d:3]" {
+		t.Errorf("delpaths: got %v", v4)
+	}
+	q5, _ := Parse(`del(.a.b)`)
+	c5, _ := Compile(q5)
+	in5 := map[string]any{"a": map[string]any{"b": 1.0, "c": 2.0}}
+	if v5, ok := c5.Run(in5).Next(); !ok || fmt.Sprint(v5) != "map[a:map[c:2]]" {
+		t.Errorf("del: got %v", v5)
+	}
+
+	// a wide sibling delete ( del(.[]) ) has every path share the one root, which
+	// the allocator copies once. Charging each path's spine separately would be
+	// quadratic and would falsely reject this legitimate small-result delete, so
+	// delpathsSize charges the union of the spines. This must succeed and give [].
+	q6, _ := Parse(`del(.[])`)
+	c6, _ := Compile(q6)
+	in6 := make([]any, 5000)
+	for i := range in6 {
+		in6[i] = i
+	}
+	if v6, ok := c6.Run(in6).Next(); !ok {
+		t.Error("del(.[]) on a wide array: got no result")
+	} else if arr, isArr := v6.([]any); !isArr || len(arr) != 0 {
+		t.Errorf("del(.[]) on a wide array: got %v, want []", v6)
+	}
+}
+
+// map * map ( deepmerge ) recursively builds fresh merged maps via make(), the
+// same shape as setpath: update tracks the merged size in a per-call local
+// counter that bounds a single merge, but the result was charged to the run
+// meter only at its top level. A deep-object self-merge collected in a loop
+// ( a 1000-deep object reached ~7 GB ) allocated the merged maps unbounded.
+// deepMergeSize now charges them by walking the same overlap the merge does.
+func TestMaxAllocBoundsDeepmerge(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	src := `reduce range(1000) as $i ({}; {a: .}) as $d | [range(1000000) | ($d * $d)] | length`
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := code.Run(nil).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected an allocation error collecting deep merges, got %v", v)
+	}
+
+	// ordinary merge, and numeric / string multiply, are unaffected.
+	for _, tc := range []struct{ src, want string }{
+		{`{a: {b: 1}, c: 2} * {a: {d: 3}, e: 4}`, "map[a:map[b:1 d:3] c:2 e:4]"},
+		{`6 * 7`, "42"},
+		{`"ab" * 3`, "ababab"},
+	} {
+		q, _ := Parse(tc.src)
+		c, _ := Compile(q)
+		if v, ok := c.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+
+	// a large self-merge has full key overlap, so it builds a union-sized map
+	// ( ~2.5 MB for 55k keys ), not a len(l)+len(r)-sized one. Charging both key
+	// counts double-counted the overlap and falsely rejected it at ~2x the real
+	// size. This must succeed and return the union key count.
+	in := make(map[string]any, 55000)
+	for i := 0; i < 55000; i++ {
+		in[fmt.Sprint(i)] = i
+	}
+	qm, _ := Parse(`. as $o | $o * $o | length`)
+	cm, _ := Compile(qm)
+	if v, ok := cm.Run(in).Next(); !ok {
+		t.Error("large self-merge: got no result")
+	} else if _, isErr := v.(error); isErr {
+		t.Errorf("large self-merge falsely rejected: %v", v)
+	} else if fmt.Sprint(v) != "55000" {
+		t.Errorf("large self-merge: got %v, want 55000", v)
+	}
+}
+
+// .[] materializes a []pathValue of every element to drive the iteration. That
+// slice was pre-checked per array but never charged to the run meter, so nested
+// iteration of the same large array ( $a[] as $x | $a[] as $y | ... ) stacked
+// the uncharged slices and reached hundreds of MB while the meter saw nothing.
+// The iteration is now charged, so nested / looped iterations accumulate and trip.
+func TestMaxAllocBoundsIterPathValues(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	// five nested iterations of a 50k-element array: each materializes a 1.6 MB
+	// []pathValue, ~8 MB total, which must now trip. limit(1) keeps it from being
+	// a CPU bomb - the slices are materialized on entry, before any deep looping.
+	src := "[range(50000)] as $a | [limit(1; $a[] as $x0 | $a[] as $x1 | $a[] as $x2 | $a[] as $x3 | $a[] as $x4 | 1)] | length"
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := code.Run(nil).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected an allocation error for nested iteration, got %v", v)
+	}
+
+	// a single scan of a large array is unchanged ( one []pathValue, under the
+	// limit ), and small / nested iteration of small arrays must still work.
+	for _, tc := range []struct{ src, want string }{
+		{`[range(1000)] | any(. > 998)`, "true"},
+		{`[[1, 2], [3, 4]] | [.[] | .[]] | add`, "10"},
+		{`[range(100000)] | length`, "100000"},
+		{"[range(1000)] as $a | [limit(1; $a[] as $y0 | $a[] as $y1 | $a[] as $y2 | 1)] | length", "1"},
+	} {
+		q, _ := Parse(tc.src)
+		c, _ := Compile(q)
+		if v, ok := c.Run(nil).Next(); !ok || fmt.Sprint(v) != tc.want {
+			t.Errorf("%q: got %v, want %s", tc.src, v, tc.want)
+		}
+	}
+}
+
+// The Go-recursive builtins ( compare, encode, contains, flatten, deleteEmpty,
+// update, deepmerge, and the JSON decoder ) bound recursion depth by MaxAlloc,
+// which at a large MaxAlloc would let a deeply-nested input overflow the
+// goroutine stack - a fatal, uncatchable crash. maxRecursionDepth caps them
+// independently of MaxAlloc, turning that into a clean allocation error. This
+// exercises the JSON decoder's cap ( they all share the constant ): a string
+// nested past the cap errors instead of crashing even though MaxAlloc is huge.
+func TestMaxAllocCapsRecursionDepth(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 64 << 20 // large enough that the per-level MaxAlloc bound does not fire first
+
+	depth := maxRecursionDepth + 1000
+	doc := strings.Repeat("[", depth) + "0" + strings.Repeat("]", depth)
+	query, _ := Parse(`fromjson`)
+	code, _ := Compile(query)
+	if v, ok := code.Run(doc).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected the recursion-depth cap to error, got a value")
+	}
+
+	// a normally-nested value still decodes.
+	q2, _ := Parse(`fromjson`)
+	c2, _ := Compile(q2)
+	if v2, ok := c2.Run(`[[1,[2,[3]]]]`).Next(); !ok || fmt.Sprint(v2) != "[[1 [2 [3]]]]" {
+		t.Errorf("ordinary fromjson: got %v", v2)
+	}
+}
+
+// A Go map[string]any has a ~320-byte fixed minimum ( hmap header + a full first
+// bucket ) that allocSize's old len*24+16 missed, so a chain or collection of
+// tiny 1-key maps ran several times over the limit ( a 1M-deep 1-key chain
+// peaked ~27 MB at a 4 MiB limit ). allocSize now charges that base. This 30000-
+// deep 1-key chain is ~11 MB of real maps but was charged under 2 MB before.
+func TestMaxAllocChargesMapBase(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 4 << 20
+
+	src := `reduce range(30000) as $i (0; {($i | tostring): .})`
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := code.Run(nil).Next(); !ok {
+		t.Fatal("expected a result")
+	} else if _, isErr := v.(error); !isErr {
+		t.Errorf("expected the map-base charge to error on a deep 1-key chain, got a value")
+	}
+
+	// an ordinary small object is still fine.
+	q2, _ := Parse(`{a: .x, b: .y, c: .z}`)
+	c2, _ := Compile(q2)
+	in := map[string]any{"x": 1.0, "y": 2.0, "z": 3.0}
+	if v2, ok := c2.Run(in).Next(); !ok || fmt.Sprint(v2) != "map[a:1 b:2 c:3]" {
+		t.Errorf("small object: got %v", v2)
+	}
+}

--- a/memlimit_test.go
+++ b/memlimit_test.go
@@ -7,6 +7,18 @@ import (
 	"testing"
 )
 
+type freshNestedIter struct {
+	remaining int
+}
+
+func (iter *freshNestedIter) Next() (any, bool) {
+	if iter.remaining == 0 {
+		return nil, false
+	}
+	iter.remaining--
+	return []any{make([]any, 2000)}, true
+}
+
 // with MaxAlloc set, a memory bomb must error instead of allocating unboundedly.
 func TestMaxAllocStopsBombs(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
@@ -106,6 +118,79 @@ func TestMaxAllocStopsSingleShotBuiltins(t *testing.T) {
 	}
 }
 
+// Every native callback result goes through the VM's ownership-aware result
+// meter, including callbacks added in the future and custom callbacks unknown
+// to the builtin-name switch. A shallow-only meter sees just the one-element
+// outer array below and misses the fresh 2,000-slot child on every call.
+func TestMaxAllocMetersEveryNativeReturn(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 1 << 20 // 1 MiB
+
+	query, err := Parse(`[range(1000) | fresh_nested] | length`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query, WithFunction("fresh_nested", 0, 0, func(any, []any) any {
+		return []any{make([]any, 2000)}
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := code.Run(nil).Next()
+	if !ok {
+		t.Fatal("expected an allocation error, got no result")
+	}
+	if _, isAlloc := v.(*allocLimitError); !isAlloc {
+		t.Errorf("expected *allocLimitError for an unknown nested producer, got %v", v)
+	}
+
+	iterQuery, err := Parse(`[fresh_nested_iter] | length`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iterCode, err := Compile(iterQuery, WithIterFunction("fresh_nested_iter", 0, 0, func(any, []any) Iter {
+		return &freshNestedIter{remaining: 1000}
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok = iterCode.Run(nil).Next()
+	if !ok {
+		t.Fatal("expected an iterator allocation error, got no result")
+	}
+	if _, isAlloc := v.(*allocLimitError); !isAlloc {
+		t.Errorf("expected *allocLimitError for an unknown iterator producer, got %v", v)
+	}
+}
+
+// Values pulled from input(s) belong to the caller, like the root value passed
+// to Run, and must not consume the query's allocation budget merely by crossing
+// the native-call return boundary.
+func TestMaxAllocLeavesPulledInputFree(t *testing.T) {
+	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
+	MaxAlloc = 1 << 20 // 1 MiB
+
+	pulled := make([]any, 100000) // larger than MaxAlloc by allocSize
+	query, err := Parse(`input`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := Compile(query, WithInputIter(NewIter(pulled)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := code.Run(nil).Next()
+	if !ok {
+		t.Fatal("expected the pulled input")
+	}
+	if _, isErr := v.(error); isErr {
+		t.Fatalf("pulled input was charged as query output: %v", v)
+	}
+	if got, isArray := v.([]any); !isArray || len(got) != len(pulled) {
+		t.Fatalf("unexpected pulled input: %T len=%d", v, len(got))
+	}
+}
+
 // deep or infinite recursion grows the interpreter's own stacks (operands,
 // forks, scopes) without ever completing a value, so the value meter never
 // charges it. and a big.Int can grow past the value meter because its size is
@@ -136,6 +221,12 @@ func TestMaxAllocStopsRecursionAndBigint(t *testing.T) {
 		v, ok := code.Run(c.in).Next()
 		if !ok {
 			t.Errorf("%q: expected an error, got no result", c.src)
+		} else if c.src == `def f: [f]; f` {
+			switch v.(type) {
+			case *stackLimitError, *allocLimitError:
+			default:
+				t.Errorf("%q: expected a stack or allocation limit error, got %v", c.src, v)
+			}
 		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
 			t.Errorf("%q: expected *allocLimitError, got %v", c.src, v)
 		}
@@ -223,8 +314,12 @@ func TestMaxAllocStopsValueSlotGrowth(t *testing.T) {
 		v, ok := code.Run("x").Next()
 		if !ok {
 			t.Errorf("expected an error, got no result")
-		} else if _, isAlloc := v.(*allocLimitError); !isAlloc {
-			t.Errorf("expected *allocLimitError, got %v", v)
+		} else {
+			switch v.(type) {
+			case *stackLimitError, *allocLimitError:
+			default:
+				t.Errorf("expected a stack or allocation limit error, got %v", v)
+			}
 		}
 	}
 }
@@ -1567,7 +1662,7 @@ func TestMaxAllocBoundsDAGAssignment(t *testing.T) {
 // top-level match map ( ~112 bytes ) while the object holds one capture map per
 // group. A query collecting many matches, each with many capture groups,
 // allocated hundreds of MB ( a short regex reached ~950 MB ) while the meter saw
-// almost nothing. matchResultSize now charges the captures' real size.
+// almost nothing. The universal native-result meter charges their real size.
 func TestMaxAllocBoundsMatchCaptures(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
 	MaxAlloc = 4 << 20
@@ -1601,7 +1696,7 @@ func TestMaxAllocBoundsMatchCaptures(t *testing.T) {
 // decode, but the result was otherwise charged at its top level only, so a
 // query collecting many decodes of a deeply-nested JSON string ( a ~40 KB
 // string reached ~3.7 GB ) allocated unbounded while the meter saw ~16 bytes
-// per decode. deepSize now charges the whole decoded tree at the native result.
+// per decode. The universal native-result meter charges the whole decoded tree.
 func TestMaxAllocBoundsFromjsonCollection(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
 	MaxAlloc = 4 << 20
@@ -1634,8 +1729,8 @@ func TestMaxAllocBoundsFromjsonCollection(t *testing.T) {
 // transpose builds a fresh outer array of inner arrays whose elements are refs
 // into the input. The shallow meter charged only the outer array, so an N-by-2
 // transpose ( two wide inner arrays ) collected in a loop reached ~2.2 GB while
-// the meter saw ~48 bytes per result. transposeResultSize now charges the inner
-// arrays' slots. ( Round 120 missed this: it tested the 2-by-N orientation,
+// the meter saw ~48 bytes per result. The universal native-result meter charges
+// the inner arrays' slots. ( Round 120 missed this: it tested the 2-by-N orientation,
 // which is many NARROW inner arrays and stays bounded. )
 func TestMaxAllocBoundsTransposeCollection(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
@@ -1670,7 +1765,7 @@ func TestMaxAllocBoundsTransposeCollection(t *testing.T) {
 // to the target and shares the rest of the input by reference. The shallow
 // meter charged only the top of the result, so a deep-path setpath collected in
 // a loop ( a 1000-deep path reached ~2 GB ) allocated the spine unbounded.
-// spineSize now charges the copied spine, while leaving a shallow assignment
+// The universal native-result meter charges the copied spine, while leaving a shallow assignment
 // charged as before ( its spine is just the top ).
 func TestMaxAllocBoundsSetpathSpine(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
@@ -1713,8 +1808,8 @@ func TestMaxAllocBoundsSetpathSpine(t *testing.T) {
 // the same copy-on-write as setpath, but was not in the deep-charge switch: the
 // run meter saw only the shallow top of the result, so collecting many deep-path
 // deletions of a bound value allocated the copied spines unbounded ( a 1000-deep
-// object deleted in a loop peaked ~75 MB at a 4 MiB limit ). delpathsSize now
-// charges each path's spine from the input, matching what update copies. Both
+// object deleted in a loop peaked ~75 MB at a 4 MiB limit ). The universal
+// native-result meter charges every copied spine by identity. Both
 // the native "delpaths" and the assignment "_delpaths" opcode are covered.
 func TestMaxAllocBoundsDelpathsSpine(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
@@ -1757,7 +1852,7 @@ func TestMaxAllocBoundsDelpathsSpine(t *testing.T) {
 	// a wide sibling delete ( del(.[]) ) has every path share the one root, which
 	// the allocator copies once. Charging each path's spine separately would be
 	// quadratic and would falsely reject this legitimate small-result delete, so
-	// delpathsSize charges the union of the spines. This must succeed and give [].
+	// the result meter charges the union of the spines. This must succeed and give [].
 	q6, _ := Parse(`del(.[])`)
 	c6, _ := Compile(q6)
 	in6 := make([]any, 5000)
@@ -1776,7 +1871,7 @@ func TestMaxAllocBoundsDelpathsSpine(t *testing.T) {
 // counter that bounds a single merge, but the result was charged to the run
 // meter only at its top level. A deep-object self-merge collected in a loop
 // ( a 1000-deep object reached ~7 GB ) allocated the merged maps unbounded.
-// deepMergeSize now charges them by walking the same overlap the merge does.
+// The universal native-result meter charges every fresh merged-map spine.
 func TestMaxAllocBoundsDeepmerge(t *testing.T) {
 	defer func(o int64) { MaxAlloc = o }(MaxAlloc)
 	MaxAlloc = 4 << 20

--- a/operator.go
+++ b/operator.go
@@ -323,6 +323,9 @@ func funcOpAdd(_, l, r any) any {
 			if len(r) == 0 {
 				return l
 			}
+			if arrayTooLarge(len(l) + len(r)) {
+				return &allocLimitError{}
+			}
 			v := make([]any, len(l)+len(r))
 			copy(v, l)
 			copy(v[len(l):], r)
@@ -334,6 +337,9 @@ func funcOpAdd(_, l, r any) any {
 			}
 			if len(r) == 0 {
 				return l
+			}
+			if MaxAlloc > 0 && int64(len(l)+len(r))*24 > MaxAlloc {
+				return &allocLimitError{}
 			}
 			m := make(map[string]any, len(l)+len(r))
 			maps.Copy(m, l)
@@ -365,6 +371,9 @@ func funcOpSub(_, l, r any) any {
 		func(l, r *big.Int) any { return new(big.Int).Sub(l, r) },
 		func(l, r string) any { return &binopTypeError{"subtract", l, r} },
 		func(l, r []any) any {
+			if arrayTooLarge(len(l)) {
+				return &allocLimitError{}
+			}
 			v := make([]any, 0, len(l))
 		L:
 			for _, l := range l {
@@ -395,7 +404,12 @@ func funcOpMul(_, l, r any) any {
 			return x.Mul(x, y)
 		},
 		func(l, r float64) any { return l * r },
-		func(l, r *big.Int) any { return new(big.Int).Mul(l, r) },
+		func(l, r *big.Int) any {
+			if MaxAlloc > 0 && int64(l.BitLen()+r.BitLen())/8 > MaxAlloc {
+				return &allocLimitError{}
+			}
+			return new(big.Int).Mul(l, r)
+		},
 		func(l, r string) any { return &binopTypeError{"multiply", l, r} },
 		func(l, r []any) any { return &binopTypeError{"multiply", l, r} },
 		deepMergeObjects,
@@ -416,13 +430,28 @@ func funcOpMul(_, l, r any) any {
 }
 
 func deepMergeObjects(l, r map[string]any) any {
+	var size int64
+	return deepMergeObjectsLimited(l, r, &size, 0)
+}
+
+func deepMergeObjectsLimited(l, r map[string]any, size *int64, depth int) any {
+	if MaxAlloc > 0 && depth > maxRecursionDepth {
+		return &allocLimitError{}
+	}
+	if *size += int64(len(l)+len(r)) * 24; MaxAlloc > 0 && *size > MaxAlloc {
+		return &allocLimitError{}
+	}
 	m := make(map[string]any, len(l)+len(r))
 	maps.Copy(m, l)
 	for k, v := range r {
 		if mk, ok := m[k]; ok {
 			if mk, ok := mk.(map[string]any); ok {
 				if w, ok := v.(map[string]any); ok {
-					v = deepMergeObjects(mk, w)
+					merged := deepMergeObjectsLimited(mk, w, size, depth+1)
+					if _, ok := merged.(*allocLimitError); ok {
+						return merged
+					}
+					v = merged
 				}
 			}
 		}
@@ -437,6 +466,9 @@ func repeatString(s string, n float64) any {
 	}
 	c := int(min(n, math.MaxInt32))
 	if uint64(len(s))*uint64(c) >= math.MaxInt32 {
+		return &repeatStringTooLargeError{s, n}
+	}
+	if MaxAlloc > 0 && int64(len(s))*int64(c) > MaxAlloc {
 		return &repeatStringTooLargeError{s, n}
 	}
 	return strings.Repeat(s, c)
@@ -476,6 +508,9 @@ func funcOpDiv(_, l, r any) any {
 		func(l, r string) any {
 			if l == "" {
 				return []any{}
+			}
+			if arrayTooLarge(strings.Count(l, r) + 1) {
+				return &allocLimitError{}
 			}
 			xs := strings.Split(l, r)
 			vs := make([]any, len(xs))

--- a/preview.go
+++ b/preview.go
@@ -72,6 +72,10 @@ func (w *limitedWriter) WriteString(s string) (int, error) {
 	return n, nil
 }
 
+func (w *limitedWriter) Len() int {
+	return w.off
+}
+
 func (w *limitedWriter) Bytes() []byte {
 	return w.buf[:w.off]
 }

--- a/stack.go
+++ b/stack.go
@@ -15,12 +15,15 @@ func newStack() *stack {
 	return &stack{index: -1, limit: -1}
 }
 
-func (s *stack) push(v any) {
+func (s *stack) push(v any, maxDepth int) {
 	b := block{v, s.index}
 	s.index = max(s.index, s.limit) + 1
 	if s.index < len(s.data) {
 		s.data[s.index] = b
 	} else {
+		if s.index >= maxDepth {
+			panic(&stackLimitError{})
+		}
 		s.data = append(s.data, b)
 	}
 }

--- a/stacklimit.go
+++ b/stacklimit.go
@@ -1,0 +1,40 @@
+package gojq
+
+// defaultMaxStackDepth bounds each live interpreter stack to 4096 entries.
+// On a 64-bit build, the operand/path blocks, scope blocks, forks, and value
+// slots are 24, 24, 56, 80, and 16 bytes respectively. Even allowing nearly
+// 2x slice-capacity growth, their combined backing storage stays below 2 MiB.
+const defaultMaxStackDepth = 1 << 12
+
+// MaxStackDepth bounds the interpreter stacks and logical user-function call
+// depth of each metered query execution. The value is captured when a run
+// starts, so stack state and enforcement remain per-run. Set it once before
+// running queries; values below one reject every query. For compatibility with
+// gojq's historically unlimited mode, the default is enforced when MaxAlloc is
+// enabled; explicitly changing MaxStackDepth also enables it without MaxAlloc.
+var MaxStackDepth = defaultMaxStackDepth
+
+func configuredStackDepth() int {
+	if MaxAlloc <= 0 && MaxStackDepth == defaultMaxStackDepth {
+		return int(^uint(0) >> 1)
+	}
+	return MaxStackDepth
+}
+
+type stackLimitError struct{}
+
+func (*stackLimitError) Error() string {
+	return "interpreter stack exceeds the configured depth limit"
+}
+
+// checkStackDepth is called before growing an interpreter stack. Keeping the
+// configured limit on env makes the hot path one per-run integer comparison.
+func (env *env) checkStackDepth(depth int) {
+	if depth > env.maxStackDepth {
+		panic(&stackLimitError{})
+	}
+}
+
+func nextScopeDepth(s *scopeStack) int {
+	return max(s.index, s.limit) + 2
+}

--- a/stacklimit_test.go
+++ b/stacklimit_test.go
@@ -1,0 +1,195 @@
+package gojq
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func compileStackLimitQuery(t *testing.T, src string) *Code {
+	t.Helper()
+	query, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", src, err)
+	}
+	code, err := Compile(query)
+	if err != nil {
+		t.Fatalf("Compile(%q): %v", src, err)
+	}
+	return code
+}
+
+func nextWithStackLimitTimeout(t *testing.T, code *Code, input any) (any, bool) {
+	t.Helper()
+	type result struct {
+		value any
+		ok    bool
+	}
+	resultc := make(chan result, 1)
+	go func() {
+		value, ok := code.Run(input).Next()
+		resultc <- result{value, ok}
+	}()
+	select {
+	case result := <-resultc:
+		return result.value, result.ok
+	case <-time.After(time.Second):
+		t.Fatal("query did not reach the stack limit within one second")
+		return nil, false
+	}
+}
+
+func TestStackLimitStopsPureRecursionFast(t *testing.T) {
+	defer func(oldDepth int, oldAlloc int64) {
+		MaxStackDepth, MaxAlloc = oldDepth, oldAlloc
+	}(MaxStackDepth, MaxAlloc)
+	MaxStackDepth, MaxAlloc = 64, 0
+
+	code := compileStackLimitQuery(t, `def f: f; f`)
+	start := time.Now()
+	value, ok := nextWithStackLimitTimeout(t, code, nil)
+	if !ok {
+		t.Fatal("pure recursion returned no error")
+	}
+	if _, isStackLimit := value.(*stackLimitError); !isStackLimit {
+		t.Fatalf("pure recursion returned %T (%v), want *stackLimitError", value, value)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("pure recursion reached the stack limit too slowly: %v", elapsed)
+	} else {
+		t.Logf("pure recursion reached the depth-64 limit in %v", elapsed)
+	}
+}
+
+func TestStackLimitStopsValueRecursionAndNestedForks(t *testing.T) {
+	defer func(oldDepth int, oldAlloc int64) {
+		MaxStackDepth, MaxAlloc = oldDepth, oldAlloc
+	}(MaxStackDepth, MaxAlloc)
+	MaxStackDepth, MaxAlloc = 64, 1<<20
+
+	for _, src := range []string{
+		`def f: [f]; f`,
+		`def f: (f, empty); f`,
+		`def f: . as $x | f; f`,
+	} {
+		value, ok := nextWithStackLimitTimeout(t, compileStackLimitQuery(t, src), nil)
+		if !ok {
+			t.Errorf("%q returned no error", src)
+			continue
+		}
+		switch value.(type) {
+		case *stackLimitError, *allocLimitError:
+		default:
+			t.Errorf("%q returned %T (%v), want a stack or allocation limit error", src, value, value)
+		}
+	}
+}
+
+func TestDefaultStackLimitBoundsBackingStorage(t *testing.T) {
+	var value any
+	bytesPerDepth := 2*unsafe.Sizeof(block{}) +
+		unsafe.Sizeof(scopeBlock{}) +
+		unsafe.Sizeof(fork{}) +
+		unsafe.Sizeof(value)
+	// Go slice capacity can be almost twice its length at a growth boundary.
+	upperBound := 2 * uintptr(defaultMaxStackDepth) * bytesPerDepth
+	if upperBound >= 2<<20 {
+		t.Fatalf("default stack backing upper bound is %d bytes, want under 2 MiB", upperBound)
+	}
+	t.Logf("default stack backing upper bound: %d bytes", upperBound)
+}
+
+func TestStackLimitAllowsBoundedPrograms(t *testing.T) {
+	defer func(oldDepth int, oldAlloc int64) {
+		MaxStackDepth, MaxAlloc = oldDepth, oldAlloc
+	}(MaxStackDepth, MaxAlloc)
+	MaxStackDepth, MaxAlloc = defaultMaxStackDepth, 1<<20
+
+	matcher := compileStackLimitQuery(t, `[.status.conditions[] | select(.type=="Cond0") | .status][0]`)
+	workload := map[string]any{"status": map[string]any{"conditions": []any{
+		map[string]any{"type": "Cond0", "status": "True"},
+		map[string]any{"type": "Cond1", "status": "False"},
+	}}}
+	if value, ok := matcher.Run(workload).Next(); !ok || value != "True" {
+		t.Fatalf("workload matcher returned %v, %v; want True, true", value, ok)
+	}
+
+	const nesting = 64
+	nested := compileStackLimitQuery(t, strings.Repeat("[", nesting)+"."+strings.Repeat("]", nesting))
+	value, ok := nested.Run(1.0).Next()
+	if !ok {
+		t.Fatal("bounded nested expression returned no value")
+	}
+	want := any(1.0)
+	for range nesting {
+		want = []any{want}
+	}
+	if !reflect.DeepEqual(value, want) {
+		t.Fatal("bounded nested expression returned the wrong value")
+	}
+}
+
+func TestStackLimitTailDepthResetsAfterReturn(t *testing.T) {
+	defer func(oldDepth int, oldAlloc int64) {
+		MaxStackDepth, MaxAlloc = oldDepth, oldAlloc
+	}(MaxStackDepth, MaxAlloc)
+	MaxStackDepth, MaxAlloc = 128, 0
+
+	code := compileStackLimitQuery(t, `def countdown: if . > 0 then . - 1 | countdown else . end; [countdown, countdown]`)
+	if value, ok := code.Run(100).Next(); !ok || fmt.Sprint(value) != "[0 0]" {
+		t.Fatalf("two bounded tail-recursive calls returned %v, %v; want [0 0], true", value, ok)
+	}
+}
+
+func TestStackLimitConcurrentRunsIsolated(t *testing.T) {
+	defer func(oldDepth int, oldAlloc int64) {
+		MaxStackDepth, MaxAlloc = oldDepth, oldAlloc
+	}(MaxStackDepth, MaxAlloc)
+	MaxStackDepth, MaxAlloc = 128, 0
+
+	unbounded := compileStackLimitQuery(t, `def f: f; f`)
+	bounded := compileStackLimitQuery(t, `reduce .[] as $x (0; . + $x)`)
+	numbers := make([]any, 1000)
+	for i := range numbers {
+		numbers[i] = i
+	}
+
+	type result struct {
+		value any
+		ok    bool
+	}
+	start := make(chan struct{})
+	unboundedResult := make(chan result, 1)
+	boundedResult := make(chan result, 1)
+	go func() {
+		<-start
+		value, ok := unbounded.Run(nil).Next()
+		unboundedResult <- result{value, ok}
+	}()
+	go func() {
+		<-start
+		value, ok := bounded.Run(numbers).Next()
+		boundedResult <- result{value, ok}
+	}()
+	close(start)
+
+	select {
+	case result := <-unboundedResult:
+		if _, isStackLimit := result.value.(*stackLimitError); !result.ok || !isStackLimit {
+			t.Errorf("unbounded concurrent run returned %T (%v), %v; want *stackLimitError, true", result.value, result.value, result.ok)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("unbounded concurrent run did not reach its stack limit")
+	}
+	select {
+	case result := <-boundedResult:
+		if !result.ok || fmt.Sprint(result.value) != "499500" {
+			t.Errorf("bounded concurrent run returned %v, %v; want 499500, true", result.value, result.ok)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bounded concurrent run did not finish")
+	}
+}


### PR DESCRIPTION
When gojq runs untrusted queries as a library, `RunWithContext` bounds time but nothing bounds memory, so a hostile query keeps allocating until the kernel OOM killer takes down the whole embedding process. A deadline does not help much: as measured in #298, `[range(10000000)]` reaches 539 MiB in about a second, and `def f: [f]; f` reached ~7 GiB before a 5 s deadline fired.

This adds an opt-in allocation budget:

```go
gojq.MaxAlloc = 4 << 20 // bytes; 0 (the default) means unlimited
```

When the budget is exceeded, the run stops with an allocation error, like any other runtime error. When unset, the accounting is skipped entirely and behavior is exactly as before. The counter lives on the per-run execution environment, so concurrent runs are isolated, and it is monotonic: it bounds the total a run materializes, not live memory. That way allocate-and-discard loops are bounded too, and no reference counting is needed - which was the difficulty named when a memory limit came up in #85. The custom function interface `func(any, []any) any` is unchanged here.

Charging happens at the VM opcodes that create values (array collection, object construction, iteration), plus a stack depth bound for runaway recursion. Builtin results are charged at the interpreter's call-return site; six builtins whose results hold nested fresh structure (regex match, fromjson, transpose, setpath, delpaths, object multiplication) are deep-sized there, sharing-aware, so copy-on-write results are not double counted. Builtins that can build a huge value in one step (string repetition, implode, @base64, strftime, fromjson decode, and others) check the size computed from their inputs before building. The JSON encoder, value comparison, the compiled regexp cache, and error previews are bounded as well, so the limit cannot be bypassed through encoding, sorting, or error formatting.

With MaxAlloc at 4 MiB the examples above stop at a few MiB of peak heap. The README library-usage section gets one note. memlimit_test.go adds 52 tests, each pairing a query that must stop with an ordinary query that must keep working (bounds, sharing, concurrency isolation, try/catch, custom functions); `make test` (the full suite under `-race`) passes in ~28 s, `make lint` (staticcheck, all checks) is clean, and GOARCH=386 builds.

This is a single commit but I am happy to split it into smaller pieces if that makes review easier. Proposed in #298.
