### PR TITLE
fix split/1 function against empty input string

### DIFF
--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -2407,6 +2407,29 @@
     "/a,b/c/d/e,f/"
     ",/ /a/,/b/,/ /c/,/ /d/,/ /e/,/f/,/ "
 
+- name: split/1 function against the divide operator
+  args:
+    - -c
+    - '.[] as $t | .[] as $s | $s | split($t)'
+  input: '["abc", "a", "b", ""]'
+  expected: |
+    ["",""]
+    ["a"]
+    ["b"]
+    []
+    ["","bc"]
+    ["",""]
+    ["b"]
+    []
+    ["a","c"]
+    ["a"]
+    ["",""]
+    []
+    ["a","b","c"]
+    ["a"]
+    ["b"]
+    []
+
 - name: join function
   args:
     - 'join(",")'

--- a/cli/test.yaml
+++ b/cli/test.yaml
@@ -2407,7 +2407,7 @@
     "/a,b/c/d/e,f/"
     ",/ /a/,/b/,/ /c/,/ /d/,/ /e/,/f/,/ "
 
-- name: split/1 function against the divide operator
+- name: split/1 function against empty string
   args:
     - -c
     - '.[] as $t | .[] as $s | $s | split($t)'

--- a/func.go
+++ b/func.go
@@ -769,6 +769,15 @@ func funcSplit(v, x any) any {
 	if !ok {
 		return &func0TypeError{"split", x}
 	}
+	return splitString(s, t)
+}
+
+// splitString implements both split/1 and the division operator on strings.
+// An empty input string yields an empty array, not a single empty string.
+func splitString(s, t string) []any {
+	if s == "" {
+		return []any{}
+	}
 	ss := strings.Split(s, t)
 	xs := make([]any, len(ss))
 	for i, s := range ss {

--- a/operator.go
+++ b/operator.go
@@ -473,17 +473,7 @@ func funcOpDiv(_, l, r any) any {
 			}
 			return bigToFloat(l) / bigToFloat(r)
 		},
-		func(l, r string) any {
-			if l == "" {
-				return []any{}
-			}
-			xs := strings.Split(l, r)
-			vs := make([]any, len(xs))
-			for i, x := range xs {
-				vs[i] = x
-			}
-			return vs
-		},
+		func(l, r string) any { return splitString(l, r) },
 		func(l, r []any) any { return &binopTypeError{"divide", l, r} },
 		func(l, r map[string]any) any { return &binopTypeError{"divide", l, r} },
 		func(l, r any) any { return &binopTypeError{"divide", l, r} },


### PR DESCRIPTION
`split/1` and the `/` operator disagree on an empty input string (v0.12.19 and main):

```
$ echo '""' | gojq -c 'split("a"), (. / "a")'
[""]
[]
$ echo '""' | jq -c 'split("a"), (. / "a")'
[]
[]
```

`funcOpDiv`'s string branch carries an empty-string case, added in 7456284 "fix division against empty string" (2019-05-02). `funcSplit`, written later in b44ae25 (2019-07-23), calls `strings.Split` unguarded and never picked it up. jq cannot drift this way: `binop_divide` and `f_string_split` both call the same `jv_string_split`, whose loop simply never runs on an empty string.

So this extracts `splitString` and calls it from both, rather than adding a second copy of the guard.

Verification, jq 1.8.2 as the oracle, over 20x20 = 400 (string, separator) pairs:

- jq's `split($t)` and `$s / $t` agree on all 400 rows
- gojq main differs from jq on 19 rows; with this patch, 0
- gojq `split/1` vs its own `/`: 0 mismatches after, 19 before

`go test -race ./...` is 1095 pass / 0 fail. Reverting func.go and operator.go while keeping the new test gives 2 failures, so the test is load-bearing.

Honest note: a one-line `if s == ""` inside `funcSplit` also passes everything. I picked the shared helper because the duplication is the mechanism that produced the bug — the guard was added to one copy two months before the other was written.
